### PR TITLE
docs: RCAN v2.0 specification proposal

### DIFF
--- a/docs/roadmap/v2.0-proposal.md
+++ b/docs/roadmap/v2.0-proposal.md
@@ -1,0 +1,331 @@
+# RCAN v2.0 Specification Proposal
+
+> **Status**: Proposal (Draft) | **Author**: ContinuonAI | **Date**: 2026-03-24
+> **Target**: Q1 2027 | **Depends on**: v1.10 (current), RCAN Foundation formation (Q3–Q4 2026)
+
+---
+
+## 1. Executive Summary
+
+RCAN v2.0 is the first major version bump of the protocol. It introduces **breaking wire-format changes** that cannot be made under the v1.x backwards-compatibility guarantee. The release consolidates lessons learned from v1.0–v1.10 and addresses four strategic areas:
+
+1. **Signed firmware manifests** — cryptographic proof of robot software provenance
+2. **Supply chain attestation** — hardware and software bill-of-materials on the wire
+3. **ISO/TC 299 alignment** — formal liaison with the robotics safety standards body
+4. **EU AI Act Article 16 reference implementation** — production-ready compliance for high-risk AI systems
+
+v2.0 also completes the **deprecation cycle** started in v1.8 by removing legacy aliases and cleaning up the wire format.
+
+---
+
+## 2. Motivation
+
+### 2.1 Why a Major Version?
+
+The RCAN versioning policy (see `VERSIONING.md`) guarantees that all v1.x implementations can interoperate. Several changes required for v2.0 violate this guarantee:
+
+- **New required fields** in the message envelope (firmware manifest hash, attestation chain)
+- **Removal of deprecated aliases** (`FEDERATION_SYNC`, `ALERT`, `AUDIT` in rcan-ts)
+- **RURI format extension** with an optional signed component that changes parsing semantics
+- **Role level restructuring** to accommodate machine-to-machine authorization tiers
+
+Per policy, these changes can only land in a MAJOR version bump.
+
+### 2.2 External Drivers
+
+| Driver | Deadline | Impact |
+|--------|----------|--------|
+| EU AI Act (2024/1689) Article 16 | August 2026 enforcement | High-risk AI systems must maintain technical documentation, traceability, and post-market monitoring. v2.0 provides wire-level compliance. |
+| ISO/TC 299 (Robotics) | Ongoing | International safety standards for service robots (ISO 13482) and industrial robots (ISO 10218). v2.0 aligns RCAN safety invariants with ISO normative requirements. |
+| NIST AI RMF | 2026 updates | Risk management framework for AI systems. v2.0 audit trail maps directly to NIST RMF functions (Govern, Map, Measure, Manage). |
+| Supply chain attacks | Ongoing | Firmware integrity attacks on IoT/robotics. v2.0 makes firmware provenance verifiable at the protocol level. |
+
+---
+
+## 3. Breaking Changes
+
+### 3.1 Deprecated Alias Removal
+
+The following rcan-ts aliases, deprecated in v1.8, are **removed** in v2.0:
+
+| Deprecated Alias | Canonical Name | Value |
+|-----------------|----------------|-------|
+| `FEDERATION_SYNC` | `FLEET_COMMAND` | 23 |
+| `ALERT` | `FAULT_REPORT` | 26 |
+| `AUDIT` | `TRANSPARENCY` | 16 |
+
+**Migration**: Replace all alias usage with canonical names. The `rcan-ts` v1.x SDK will emit deprecation warnings; v2.0 SDK will throw on alias usage.
+
+### 3.2 Message Envelope Changes
+
+New **required** fields in the v2.0 envelope:
+
+```protobuf
+message RCANMessage {
+  // ... existing v1.x fields (1–12) ...
+
+  // NEW in v2.0 — required for all messages
+  string firmware_hash    = 13;  // SHA-256 of sender's firmware manifest
+  string attestation_ref  = 14;  // URI to SBOM/attestation document (optional, empty string if none)
+
+  // NEW in v2.0 — required for COMMAND and INVOKE messages
+  string delegation_chain = 15;  // Serialized delegation chain (§12 v1.5 format, now required)
+}
+```
+
+A v1.x receiver encountering these fields will ignore them (unknown field handling). A v2.0 receiver will **reject** messages missing `firmware_hash`.
+
+### 3.3 RURI Format Extension
+
+v2.0 extends the RURI format to optionally include a signed identity component:
+
+```
+# v1.x format (still valid)
+rcan://registry.rcan.dev/manufacturer/model/version/device-id
+
+# v2.0 extended format
+rcan://registry.rcan.dev/manufacturer/model/version/device-id?sig=<base64url>
+```
+
+The `sig` query parameter carries a detached Ed25519 signature over the RURI path, created by the robot's registered key. This allows offline identity verification without a registry roundtrip.
+
+### 3.4 Role Level Restructuring
+
+v2.0 introduces machine-to-machine (M2M) authorization tiers alongside human roles:
+
+| Level | v1.x Name | v2.0 Name | Change |
+|-------|-----------|-----------|--------|
+| 1 | GUEST | GUEST | No change |
+| 2 | OPERATOR | OPERATOR | No change |
+| 2.5 | *(contribute scope)* | CONTRIBUTOR | Formalized as a proper level |
+| 3 | ADMIN | ADMIN | No change |
+| 4 | *(new)* | M2M_PEER | Robot-to-robot peer authorization |
+| 5 | CREATOR | CREATOR | No change |
+| 6 | *(new)* | M2M_TRUSTED | Pre-authorized fleet peer (e.g. same-owner robots) |
+
+---
+
+## 4. New Features
+
+### 4.1 Signed Firmware Manifests
+
+Every RCAN v2.0 robot MUST publish a firmware manifest at:
+
+```
+{ruri}/.well-known/rcan-firmware-manifest.json
+```
+
+The manifest is Ed25519-signed by the manufacturer's key registered in the RRF:
+
+```json
+{
+  "rrn": "RRN-000000000001",
+  "firmware_version": "v2026.4.1.0",
+  "build_hash": "sha256:a1b2c3d4...",
+  "components": [
+    {
+      "name": "brain-runtime",
+      "version": "3.2.0",
+      "hash": "sha256:e5f6a7b8..."
+    },
+    {
+      "name": "safety-stack",
+      "version": "1.8.0",
+      "hash": "sha256:c9d0e1f2..."
+    }
+  ],
+  "signed_at": "2026-04-01T00:00:00Z",
+  "manufacturer_key_id": "key-acme-2026-prod",
+  "signature": "base64url..."
+}
+```
+
+**Conformance requirement**: A v2.0 L2+ implementation MUST verify the firmware manifest signature on first connection and on every firmware update. A failed signature check MUST trigger a `FAULT_REPORT` (26) with `fault_code: "FIRMWARE_INTEGRITY_FAILURE"`.
+
+### 4.2 Supply Chain Attestation (SBOM)
+
+v2.0 defines a standard for robots to advertise their software bill of materials:
+
+```
+{ruri}/.well-known/rcan-sbom.json
+```
+
+Format follows [CycloneDX](https://cyclonedx.org/) v1.5+ with RCAN extensions:
+
+```json
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:...",
+  "version": 1,
+  "metadata": {
+    "rcan_rrn": "RRN-000000000001",
+    "rcan_firmware_hash": "sha256:a1b2c3d4..."
+  },
+  "components": [
+    {
+      "type": "firmware",
+      "name": "opencastor-brain",
+      "version": "3.2.0",
+      "hashes": [{"alg": "SHA-256", "content": "..."}],
+      "supplier": {"name": "ContinuonAI"}
+    }
+  ]
+}
+```
+
+The `attestation_ref` field in the v2.0 message envelope points to this SBOM endpoint, enabling any message recipient to verify the sender's software supply chain.
+
+### 4.3 ISO/TC 299 Alignment
+
+v2.0 introduces normative references to ISO safety standards and maps RCAN provisions to ISO requirements:
+
+| RCAN Provision | ISO Standard | ISO Clause | Mapping |
+|---------------|-------------|------------|---------|
+| §6 Safety invariants | ISO 13482:2014 | §5.3 Safety functions | RCAN ESTOP semantics map to ISO 13482 protective stop |
+| §2 RBAC | ISO 10218-2:2011 | §5.2.2 Access control | RCAN role levels satisfy ISO access control requirements |
+| §16 Transparency | ISO/IEC 42001:2023 | §6.1.2 AI risk | RCAN audit chain provides evidence for ISO AI management |
+| §7 ConfidenceGate | ISO 13482:2014 | §5.4 Autonomous decisions | Confidence thresholds map to ISO risk-based decision gates |
+| §9 Ed25519 signing | ISO/IEC 27001:2022 | §A.8 Cryptography | Ed25519 satisfies ISO cryptographic control requirements |
+
+**New field in DISCOVER (9) payload**:
+
+```json
+{
+  "capabilities": ["..."],
+  "iso_conformance": {
+    "iso_13482": true,
+    "iso_10218_2": false,
+    "iso_42001": true
+  }
+}
+```
+
+### 4.4 EU AI Act Article 16 Reference Implementation
+
+Article 16 of the EU AI Act requires providers of high-risk AI systems to:
+
+1. **Maintain a quality management system** — v2.0 audit chain + SBOM
+2. **Keep technical documentation up to date** — firmware manifests + transparency records
+3. **Ensure logging capabilities** — RCAN commitment chain (§16) satisfies Art. 12 logging
+4. **Take corrective action** — `ROBOT_REVOCATION` (19) + `KEY_ROTATION` (27) provide withdrawal/recall capability
+5. **Cooperate with authorities** — `AUDIT_EXPORT` endpoint (v1.5) + new `AUTHORITY_ACCESS` message type
+
+**New MessageType (v2.0)**:
+
+| Value | Name | Direction | Description |
+|-------|------|-----------|-------------|
+| 41 | AUTHORITY_ACCESS | authority → robot | Regulator requests audit data access per EU AI Act Art. 16(j) |
+| 42 | AUTHORITY_RESPONSE | robot → authority | Robot provides requested audit data |
+| 43 | FIRMWARE_ATTESTATION | robot → registry | Robot publishes signed firmware manifest to registry |
+| 44 | SBOM_UPDATE | robot → registry | Robot publishes updated SBOM |
+
+---
+
+## 5. Migration Path
+
+### 5.1 Version Negotiation
+
+v2.0 implementations MUST support downward negotiation to v1.x via the `rcan_version` field in the DISCOVER handshake:
+
+```json
+{
+  "type": 9,
+  "payload": {
+    "capabilities": ["..."],
+    "rcan_version": "2.0.0",
+    "supported_versions": ["2.0", "1.10", "1.6"],
+    "min_version": "1.6"
+  }
+}
+```
+
+When a v2.0 sender communicates with a v1.x receiver, it MUST:
+- Omit v2.0-only envelope fields (`firmware_hash`, `attestation_ref`, `delegation_chain`)
+- Use only v1.x MessageType values (1–40)
+- Fall back to unsigned RURI format
+
+### 5.2 SDK Migration
+
+| SDK | v1.x (current) | v2.0 (planned) | Migration Guide |
+|-----|----------------|-----------------|-----------------|
+| rcan-py | 0.9.x | 1.0.0 | `docs/migration/rcan-py-v1-to-v2.md` |
+| rcan-ts | 0.9.x | 1.0.0 | `docs/migration/rcan-ts-v1-to-v2.md` |
+
+SDK v1.0.0 releases will coincide with spec v2.0. The `1.0.0` SDK version signals "implements RCAN v2.0".
+
+### 5.3 Deprecation Timeline
+
+| Item | Deprecated In | Removed In | Notice Period |
+|------|--------------|------------|---------------|
+| rcan-ts `FEDERATION_SYNC` alias | v1.8 (Mar 2026) | v2.0 (Q1 2027) | 10+ months |
+| rcan-ts `ALERT` alias | v1.8 (Mar 2026) | v2.0 (Q1 2027) | 10+ months |
+| rcan-ts `AUDIT` alias | v1.8 (Mar 2026) | v2.0 (Q1 2027) | 10+ months |
+| `signature: "pending"` in manufacturer verification | v1.0 (Jan 2026) | v2.0 (Q1 2027) | 12+ months |
+
+All exceed the minimum 12-month / 2-minor-version deprecation window required by the versioning policy.
+
+---
+
+## 6. Conformance
+
+### 6.1 New Conformance Level
+
+v2.0 introduces **L5: Supply Chain** on top of the existing L1–L4 hierarchy:
+
+| Level | Label | Key Requirement |
+|-------|-------|-----------------|
+| L1 | Core | DISCOVER, STATUS, COMMAND, RURI addressing, JWT auth |
+| L2 | Secure | L1 + HiTL gates, Ed25519 signing, AuditChain |
+| L3 | Federated | L2 + commitment chain, cross-registry discovery, capability advertisement |
+| L4 | Registry | L3 + REGISTRY_REGISTER/RESOLVE roundtrip, RRN validation |
+| **L5** | **Supply Chain** | **L4 + firmware manifest verification, SBOM publication, EU AI Act Art. 16 compliance** |
+
+### 6.2 Backward Compatibility Testing
+
+The v2.0 conformance suite includes a **v1.x interop** test section:
+
+- v2.0 sender → v1.10 receiver: message accepted (unknown fields ignored)
+- v1.10 sender → v2.0 receiver: message rejected if `firmware_hash` missing (unless negotiated to v1.x mode)
+- v2.0 RURI with `?sig=` → v1.x parser: query parameter ignored, path parsed correctly
+- Version negotiation roundtrip: v2.0 ↔ v1.6 settle on v1.6
+
+---
+
+## 7. Timeline
+
+| Milestone | Target Date | Description |
+|-----------|------------|-------------|
+| v2.0 RFC published | May 2026 | This proposal finalized, open for community comment |
+| RCAN Foundation formed | Q3 2026 | Foundation board reviews and ratifies v2.0 scope |
+| EU AI Act enforcement | August 2026 | Art. 16 obligations become enforceable; v1.x provides interim compliance |
+| v2.0 Draft spec | October 2026 | Complete wire-format specification with examples |
+| v2.0 SDK alphas | November 2026 | rcan-py 1.0.0a1, rcan-ts 1.0.0a1 |
+| v2.0 RC | December 2026 | Release candidate; conformance suite L5 finalized |
+| v2.0 Release | Q1 2027 | Spec, SDKs, and conformance suite published |
+
+---
+
+## 8. Open Questions
+
+1. **RURI signing**: Should the `?sig=` parameter be mandatory for all v2.0 messages, or only for cross-registry communication?
+2. **SBOM format**: CycloneDX vs SPDX — which should be normative? Should we support both?
+3. **M2M authorization**: Should M2M_PEER (level 4) require mutual TLS in addition to JWT, or is JWT sufficient?
+4. **Firmware manifest frequency**: Should robots re-attest on every boot, or only on firmware change?
+5. **ISO liaison**: Formal TC 299 liaison membership requires organizational commitment. Should this be a Foundation responsibility or a ContinuonAI contribution?
+6. **MessageType range**: Should v2.0 reserve 41–50 for regulatory message types and 51–99 for future extensions, or allow a more flexible allocation?
+7. **v1.x LTS duration**: The current policy guarantees 3 years LTS (until Jan 2029). Should v2.0 extend v1.x LTS given the installed base?
+
+---
+
+## 9. References
+
+- [RCAN Versioning Policy](../../VERSIONING.md)
+- [MessageType Numbering Plan](../../spec/sections/MESSAGE_TYPE_NUMBERING.md)
+- [EU AI Act (2024/1689)](https://eur-lex.europa.eu/eli/reg/2024/1689)
+- [ISO 13482:2014 — Robots and robotic devices — Safety requirements for personal care robots](https://www.iso.org/standard/53820.html)
+- [ISO/IEC 42001:2023 — AI management system](https://www.iso.org/standard/81230.html)
+- [CycloneDX SBOM Standard](https://cyclonedx.org/)
+- [NIST AI Risk Management Framework](https://www.nist.gov/artificial-intelligence/risk-management-framework)
+- [Manufacturer Verification Protocol](../verification/manufacturer-verification.md)
+- [v1.8 Deprecation Notices](../../src/pages/spec/v1.8.astro)


### PR DESCRIPTION
## Summary\n- Add `docs/roadmap/v2.0-proposal.md` — comprehensive v2.0 spec proposal document\n- Covers all four strategic areas from the existing roadmap vision: signed firmware manifests, supply chain attestation, ISO/TC 299 alignment, and EU AI Act Art. 16 reference implementation\n- Details breaking changes: deprecated alias removal (from v1.8), new required envelope fields, RURI signing extension, M2M role level restructuring\n- Introduces L5 Supply Chain conformance level\n- Defines 4 new MessageTypes (41–44): AUTHORITY_ACCESS, AUTHORITY_RESPONSE, FIRMWARE_ATTESTATION, SBOM_UPDATE\n- Includes migration path with version negotiation, SDK migration plan, and deprecation timeline\n- Targets Q1 2027 with milestones from May 2026 through release\n\n## Test plan\n- [x] `npm run build` — 78 pages built successfully\n- [x] `npx vitest run` — 101 tests pass\n- [ ] Review proposal content for technical accuracy and completeness\n\nhttps://claude.ai/code/session_011hFEEjhGLztQX4PQYqnNXL