### PR TITLE
feat: add pqc-hybrid-v1 cryptographic profile (issue #188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # RCAN Spec Changelog
 
+## [2.3.0] - 2026-03-31
+
+### Added
+- `pqc-hybrid-v1` cryptographic profile: Ed25519 + ML-DSA-65/Dilithium3 (NIST FIPS 204) dual-signature scheme. Both halves required; single-half sigs MUST be rejected.
+- `pqc-v1` profile defined (future, post-2028): ML-DSA-65 only.
+- `/.well-known/rcan-node.json` extended with `crypto_profile`, `pqc_public_key` (base64url), `ed25519_public_key` (base64url) fields.
+- §1.6.4: `?sig=pqc-hybrid-v1.<ed25519_b64url>.<ml_dsa_b64url>` combined encoding for signed RURIs.
+- `docs/crypto/pqc-profile.md`: canonical spec for encoding, key sizes, migration timeline, reference implementations.
+
 ## [2.2.1] - 2026-03-28
 
 ### Added

--- a/docs/crypto/pqc-profile.md
+++ b/docs/crypto/pqc-profile.md
@@ -1,0 +1,142 @@
+# RCAN Cryptographic Profiles
+
+> **Status:** Draft — targeted for RCAN v2.3.0
+> **Issue:** #188
+
+## Overview
+
+A *cryptographic profile* names a complete signing algorithm suite used throughout RCAN for:
+
+- RURI `?sig=` query parameter (§1.6)
+- `firmware_hash` envelope field, type 13 (§3)
+- `attestation_ref` envelope field, type 14 (§3)
+- M2M tokens (§11)
+
+The profile is advertised in `/.well-known/rcan-node.json` via the `crypto_profile` field (see §17).
+
+---
+
+## Profile: pqc-hybrid-v1 (Recommended — now through 2027)
+
+### Purpose
+
+Provides quantum-resistant signing while remaining verifiable by pre-v2.2 receivers that only check Ed25519. Both signature halves are REQUIRED; a message carrying only one half MUST be rejected by v2.3+ receivers.
+
+### Algorithm Suite
+
+| Component | Algorithm | Standard |
+|-----------|-----------|----------|
+| Classical | Ed25519 | RFC 8032 |
+| Post-Quantum | ML-DSA-65 / Dilithium3 | NIST FIPS 204 |
+
+### Key Sizes
+
+| Key type | Raw bytes | Base64url length |
+|----------|-----------|------------------|
+| Ed25519 public key | 32 B | 43 chars |
+| Ed25519 signature | 64 B | 86 chars |
+| ML-DSA-65 public key | 1952 B | 2603 chars |
+| ML-DSA-65 signature | 3309 B | 4412 chars |
+
+### Signature Encoding
+
+The combined signature is a single string of the form:
+
+```
+pqc-hybrid-v1.<ed25519_base64url>.<ml_dsa_base64url>
+```
+
+- `<ed25519_base64url>` — base64url (no padding) of the 64-byte Ed25519 signature
+- `<ml_dsa_base64url>` — base64url (no padding) of the 3309-byte ML-DSA-65 signature
+- The two components are separated by a literal `.`
+- The prefix `pqc-hybrid-v1` distinguishes this encoding from the legacy bare base64url format
+
+**Example (truncated for readability):**
+```
+pqc-hybrid-v1.AAAA...AAAA.BBBB...BBBB
+```
+
+### Signing Procedure
+
+```python
+# message_bytes = canonical payload to sign (e.g. RURI path bytes)
+ed25519_sig  = ed25519_sign(ed25519_private_key, message_bytes)
+ml_dsa_sig   = ml_dsa_65_sign(ml_dsa_private_key, message_bytes)
+
+combined_sig = (
+    "pqc-hybrid-v1."
+    + base64url_no_pad(ed25519_sig)
+    + "."
+    + base64url_no_pad(ml_dsa_sig)
+)
+```
+
+### Verification Procedure
+
+```python
+# sig_str = value from ?sig= or envelope field
+parts = sig_str.split(".")
+# parts[0] == "pqc-hybrid-v1", parts[1] == ed25519 half, parts[2] == ml_dsa half
+
+if len(parts) != 3 or parts[0] != "pqc-hybrid-v1":
+    raise SignatureFormatError("Not a pqc-hybrid-v1 signature")
+
+ed25519_bytes = base64url_decode(parts[1])
+ml_dsa_bytes  = base64url_decode(parts[2])
+
+# BOTH halves must verify; either failure MUST reject the message
+assert ed25519_verify(ed25519_public_key, message_bytes, ed25519_bytes), "Ed25519 half invalid"
+assert ml_dsa_65_verify(ml_dsa_public_key, message_bytes, ml_dsa_bytes), "ML-DSA-65 half invalid"
+```
+
+### Conformance Requirements
+
+- A v2.3+ node advertising `crypto_profile: "pqc-hybrid-v1"` MUST produce signatures in this combined format.
+- Receivers MUST reject any message where only one half is present.
+- Receivers MUST reject any message where either half fails verification.
+- The `ed25519_public_key` and `pqc_public_key` fields MUST both be set in `/.well-known/rcan-node.json` when using this profile.
+
+---
+
+## Profile: pqc-v1 (Future — post-2028)
+
+### Purpose
+
+ML-DSA-65 only. For use after Ed25519 sunset (2027). Receivers that support `pqc-v1` no longer need to maintain Ed25519 verification code.
+
+### Algorithm Suite
+
+| Component | Algorithm | Standard |
+|-----------|-----------|----------|
+| Post-Quantum | ML-DSA-65 / Dilithium3 | NIST FIPS 204 |
+
+### Signature Encoding
+
+```
+pqc-v1.<ml_dsa_base64url>
+```
+
+- `<ml_dsa_base64url>` — base64url (no padding) of the 3309-byte ML-DSA-65 signature
+
+### Conformance Requirements
+
+- Do NOT deploy before 2028; use `pqc-hybrid-v1` in the 2026–2027 transition period.
+- A node advertising `crypto_profile: "pqc-v1"` MUST reject legacy Ed25519-only messages.
+- The `ed25519_public_key` field is absent or null when using `pqc-v1`.
+
+---
+
+## Migration Timeline
+
+| Period | Profile | Notes |
+|--------|---------|-------|
+| 2026 – 2027 | `pqc-hybrid-v1` | Both halves required. Old receivers still verify Ed25519. |
+| 2027 | Ed25519 sunset | SDKs stop signing with Ed25519; `pqc-hybrid-v1` generators set Ed25519 half to zeros or drop it per compat mode. |
+| 2028+ | `pqc-v1` | ML-DSA-65 only. Ed25519 verification code removed. |
+
+---
+
+## Reference Implementations
+
+- **Python:** `dilithium-py` (pure-software, no native deps)
+- **TypeScript:** `@noble/post-quantum` (pure-software, no native deps)

--- a/functions/.well-known/rcan-node.json.ts
+++ b/functions/.well-known/rcan-node.json.ts
@@ -7,9 +7,13 @@ export const onRequest = () => {
     // In production, set this to your robot node's actual Ed25519 public key (e.g. "ed25519:<base58-encoded-key>").
     // For demo/reference deployments this is left null. Configure via environment variable or deployment config.
     public_key: null,
+    // PQC profile fields (RCAN v2.3+)
+    crypto_profile: "pqc-hybrid-v1",
+    pqc_public_key: null,      // base64url-encoded ML-DSA-65 public key (1952 bytes). Null in demo deployments.
+    ed25519_public_key: null,  // base64url-encoded Ed25519 public key (32 bytes). Null in demo deployments.
     api_base: "https://rcan.dev/api/v1",
     registry_ui: "https://rcan.dev/registry/",
-    spec_version: "1.3",
+    spec_version: "2.3",
     capabilities: ["register", "resolve", "verify", "delegate"],
     sync_endpoint: "https://rcan.dev/api/v1/sync",
     last_sync: new Date().toISOString(),

--- a/public/sdk-status.json
+++ b/public/sdk-status.json
@@ -1,6 +1,6 @@
 {
-  "updated": "2026-03-31T18:54:23Z",
-  "spec_version": "1.3",
+  "updated": "2026-03-31T00:00:00Z",
+  "spec_version": "2.3.0",
   "sdks": {
     "rcan-py": {
       "version": "1.1.0",

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -12,7 +12,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <div class="mb-16">
       <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-accent/10 border border-accent/20 text-accent text-sm font-medium mb-6">
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>
-        Protocol v1.10 · March 2026
+        Protocol v2.3 · March 2026
       </div>
       <h1 class="text-4xl md:text-5xl font-bold text-text mb-6 leading-tight">
         The open protocol for<br/>
@@ -123,8 +123,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
           { version: "v1.6", status: "archived", label: "Archived", desc: "4 deferred gaps closed: federated consent protocol (FEDERATION_SYNC, cross-registry JWT trust, 3-tier registry hierarchy), bandwidth-constrained transports (32-byte RCAN-Minimal for LoRa, RCAN-Compact CBOR, BLE L2CAP), multi-modal payloads (media_chunks SHA-256 audit trail, streaming), human identity LoA 1/2/3 (FIDO2, min_loa_for_control). All 22 original audit gaps addressed. rcan-py v0.6.0, rcan-ts v0.6.0." },
           { version: "v1.10", status: "live", label: "Current", desc: "Competition protocol: COMPETITION_ENTER (37), COMPETITION_SCORE (38), SEASON_STANDING (39) for fleet competition events. PERSONAL_RESEARCH_RESULT (40) for private local research runs. Canonical MessageType table extended to 40 entries." },
           { version: "v2.1", status: "stable", label: "Stable", desc: "M2M_TRUSTED (level 6), signed firmware manifests, SBOM attestation, EU AI Act §12/§16. OpenCastor v2026.3.21.2." },
-          { version: "v2.2", status: "current", label: "Latest", desc: "ML-DSA-65 primary signing (FIPS 204), Ed25519 deprecated, dual-brain VLA+Claude architecture, ISO 42001 + EU AI Act compliance. OpenCastor v2026.3.27.1." },
-          { version: "v2.2", status: "upcoming", label: "PQ Hybrid", desc: "ML-DSA-65 + Ed25519 hybrid signing (NIST FIPS 204). Q-Day protection for boot sequence and firmware attestation. Target: 2027." },
+          { version: "v2.2", status: "stable", label: "Stable", desc: "ML-DSA-65 primary signing (FIPS 204), Ed25519 deprecated, dual-brain VLA+Claude architecture, ISO 42001 + EU AI Act compliance. OpenCastor v2026.3.27.1." },
+          { version: "v2.3", status: "current", label: "Latest", desc: "pqc-hybrid-v1 cryptographic profile: Ed25519 + ML-DSA-65 (NIST FIPS 204) dual signatures. Both halves required. /.well-known/rcan-node.json extended with crypto_profile, pqc_public_key, ed25519_public_key. §1.6.4 RURI combined sig format." },
         ].map(item => (
           <div class="flex gap-6 mb-8 relative pl-10">
             <div class={`absolute left-2.5 top-1.5 w-3 h-3 rounded-full border-2 ${item.status === 'live' ? 'bg-accent border-accent' : item.status === 'planned' ? 'bg-bg border-accent/50' : 'bg-bg border-white/20'}`}></div>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -3,10 +3,23 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
 const versions = [
   {
-    version: 'v2.2.0',
-    date: '2026-03-27',
+    version: 'v2.3.0',
+    date: '2026-03-31',
     tag: 'Latest',
     tagColor: 'bg-accent/15 text-accent border-accent/30',
+    changes: [
+      { type: 'feat', text: 'pqc-hybrid-v1 profile: "pqc-hybrid-v1.<ed25519_b64url>.<ml_dsa_b64url>" — both halves required, single-half sigs MUST be rejected' },
+      { type: 'feat', text: 'pqc-v1 profile: "pqc-v1.<ml_dsa_b64url>" — ML-DSA-65 only, for use post-2028 after Ed25519 sunset' },
+      { type: 'feat', text: '/.well-known/rcan-node.json: new fields crypto_profile, pqc_public_key, ed25519_public_key' },
+      { type: 'feat', text: '§1.6.4: pqc-hybrid-v1 combined sig format for RURI ?sig= parameter' },
+      { type: 'docs', text: 'docs/crypto/pqc-profile.md: encoding, key sizes (Ed25519 64B sig / ML-DSA-65 3309B sig), migration timeline 2026→2028+, reference implementations' },
+    ],
+  },
+  {
+    version: 'v2.2.0',
+    date: '2026-03-27',
+    tag: 'Stable',
+    tagColor: 'bg-white/5 text-text-muted border-white/10',
     changes: [
       { type: 'breaking', text: 'Ed25519 fully removed — ML-DSA-65 (NIST FIPS 204) is the only signing algorithm' },
       { type: 'breaking', text: 'pq_sig field removed from wire format — signature.alg = "ml-dsa-65" is the sole signing block' },

--- a/src/pages/spec/index.astro
+++ b/src/pages/spec/index.astro
@@ -314,7 +314,7 @@ const swarmBroadcast = `// POST /api/command (broadcast to all swarm nodes)
 // castor swarm status [--json]`;
 ---
 
-<DocsLayout title="Specification v1.10.0" description="RCAN Protocol Specification v1.10.0 — robot addressing, auth, config schema, autonomous actions, sensing, telemetry, swarm, AI accountability, and fleet competitions.">
+<DocsLayout title="Specification v2.3.0" description="RCAN Protocol Specification v2.3.0 — robot addressing, auth, config schema, autonomous actions, sensing, telemetry, swarm, AI accountability, and fleet competitions.">
   <div class="flex items-center gap-4 mb-4">
     <h1 class="mb-0">RCAN Protocol Specification</h1>
   </div>

--- a/src/pages/spec/section-1.astro
+++ b/src/pages/spec/section-1.astro
@@ -32,6 +32,22 @@ sig   = base64url_decode(ruri.query_params["sig"])
 valid = ed25519_verify(manufacturer_public_key, path.encode("utf-8"), sig)
 # On failure: emit FAULT_REPORT { fault_code: "RURI_SIGNATURE_INVALID" }`;
 
+const pqcHybridSigNote = `# Signing a RURI with pqc-hybrid-v1 (pseudocode, v2.3+)
+path     = ruri.split("?")[0].replace("rcan://", "")
+ed_sig   = ed25519_sign(ed25519_private_key, path.encode("utf-8"))
+pq_sig   = ml_dsa_65_sign(ml_dsa_private_key, path.encode("utf-8"))
+combined = "pqc-hybrid-v1." + base64url(ed_sig) + "." + base64url(pq_sig)
+signed_ruri = ruri + "?sig=" + combined
+
+# Verifying (v2.3+ receiver)
+parts = sig.split(".")
+# parts[0]=="pqc-hybrid-v1", parts[1]==ed25519 half, parts[2]==ml-dsa half
+assert len(parts) == 3, "Not a pqc-hybrid-v1 sig"
+ed_ok = ed25519_verify(ed25519_pubkey, path.encode("utf-8"), base64url_decode(parts[1]))
+pq_ok = ml_dsa_65_verify(pqc_pubkey,   path.encode("utf-8"), base64url_decode(parts[2]))
+# BOTH must pass — single-half sigs MUST be rejected
+assert ed_ok and pq_ok, "RURI_SIGNATURE_INVALID"`;
+
 const ruriRegex = `# Canonical RURI
 ^rcan://([a-z0-9][a-z0-9.-]*[a-z0-9])/([a-z0-9][a-z0-9-]*[a-z0-9])/([a-z0-9][a-z0-9-]*[a-z0-9])/([0-9a-f]{8}(?:-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?)(?::(\d{1,5}))?(/[a-z][a-z0-9/-]*)?$
 
@@ -225,6 +241,26 @@ const components = [
     <p>
       The signed RURI establishes <em>who</em> is sending; the <code>firmware_hash</code> envelope field (§3, field 13) establishes <em>what software</em> they are running.
       Together they form the v2.1 sender identity proof: verified origin + verified build.
+    </p>
+
+    <h3 id="signed-ruri-pqc">1.6.4 PQC Hybrid Signing <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-accent/10 text-accent border border-accent/20 ml-2 align-middle">v2.3</span></h3>
+    <p>
+      When a node advertises <code>crypto_profile: "pqc-hybrid-v1"</code> in its
+      <code>/.well-known/rcan-node.json</code>, the <code>?sig=</code> parameter MUST use the combined
+      Ed25519 + ML-DSA-65 encoding:
+    </p>
+    <pre><code>rcan://registry.rcan.dev/manufacturer/model/version/device-id?sig=pqc-hybrid-v1.&lt;ed25519_b64url&gt;.&lt;ml_dsa_b64url&gt;</code></pre>
+    <ul>
+      <li>Both halves are REQUIRED; a signature missing either half MUST be rejected.</li>
+      <li>Receivers MUST verify both halves independently; either failure rejects the message.</li>
+      <li>Legacy Ed25519-only (<code>?sig=&lt;bare_b64url&gt;</code>) is still accepted by receivers that do not require <code>pqc-hybrid-v1</code>.</li>
+      <li>On failure: emit <code>FAULT_REPORT (26)</code> with <code>fault_code: "RURI_SIGNATURE_INVALID"</code></li>
+    </ul>
+    <div class="not-prose">
+      <CodeWindow code={pqcHybridSigNote} language="python" title="pqc-hybrid-ruri.pseudo" />
+    </div>
+    <p class="text-sm text-text-muted mt-3">
+      See <a href="/docs/crypto/pqc-profile" class="text-accent hover:underline">Cryptographic Profiles</a> for key sizes, migration timeline, and reference implementations.
     </p>
   </section>
 

--- a/src/pages/spec/v2.3.astro
+++ b/src/pages/spec/v2.3.astro
@@ -1,0 +1,122 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+
+const notices = [
+  { text: 'RCAN v2.3 defines the pqc-hybrid-v1 cryptographic profile: Ed25519 + ML-DSA-65 (NIST FIPS 204). Both signature halves are required; single-half sigs MUST be rejected.' },
+  { text: '/.well-known/rcan-node.json gains three new fields: crypto_profile, pqc_public_key (base64url, ML-DSA-65), ed25519_public_key (base64url, Ed25519).' },
+  { text: '?sig= RURI parameter extended to accept pqc-hybrid-v1.<ed25519_b64url>.<ml_dsa_b64url> combined encoding (§1.6.4).' },
+  { text: 'pqc-v1 profile (ML-DSA-65 only) defined for post-2028 migration after Ed25519 sunset.' },
+];
+
+const conformanceLevels = [
+  { level: 'L0', label: 'Unsafe',      req: 'No authentication, no signing.' },
+  { level: 'L1', label: 'Baseline',    req: 'Ed25519 message signing (§9). HiTL gates.' },
+  { level: 'L2', label: 'Secure',      req: 'L1 + pqc-hybrid-v1: Ed25519 + ML-DSA-65 (§7.2, §1.6.4). Firmware hash.' },
+  { level: 'L3', label: 'Auditable',   req: 'L2 + AuditChain + signed RURI (pqc-hybrid-v1 format).' },
+  { level: 'L4', label: 'Federated',   req: 'L3 + M2M_PEER, RBAC, delegation chain.' },
+  { level: 'L5', label: 'Compliant',   req: 'L4 + M2M_TRUSTED, RRF registration, SBOM, firmware manifest, authority handler, audit retention ≥10yr, EU AI Act §12/§16.' },
+];
+
+const newFields = [
+  { field: 'crypto_profile',    type: 'string',        desc: 'Active cryptographic profile. "pqc-hybrid-v1" (recommended) or "pqc-v1" (post-2028). Absent on pre-v2.3 nodes.' },
+  { field: 'pqc_public_key',    type: 'string | null', desc: 'base64url-encoded ML-DSA-65 public key (1952 bytes). Null in demo deployments.' },
+  { field: 'ed25519_public_key',type: 'string | null', desc: 'base64url-encoded Ed25519 public key (32 bytes). Null in demo deployments; absent for pqc-v1 nodes.' },
+];
+---
+
+<DocsLayout title="RCAN v2.3 — PQC Hybrid Profile" description="RCAN v2.3 defines the pqc-hybrid-v1 cryptographic profile: dual Ed25519 + ML-DSA-65 signatures for quantum-resistant robot communication.">
+  <div class="max-w-3xl mx-auto">
+
+    <!-- Breadcrumb -->
+    <nav class="text-sm text-text-muted mb-6">
+      <a href="/spec/" class="hover:text-accent transition-colors">Specification</a>
+      <span class="mx-2 opacity-40">/</span>
+      <span class="text-text">v2.3</span>
+    </nav>
+
+    <!-- Header -->
+    <div class="flex items-start justify-between gap-4 mb-8">
+      <div>
+        <h1 class="mb-2">RCAN v2.3</h1>
+        <p class="text-text-muted text-lg">PQC Hybrid Cryptographic Profile</p>
+      </div>
+      <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-accent/15 text-accent border border-accent/30 whitespace-nowrap mt-2">
+        Current
+      </span>
+    </div>
+
+    <!-- What's new -->
+    <section class="mb-10">
+      <h2>What's New in v2.3</h2>
+      <ul class="space-y-2 mt-4">
+        {notices.map(n => (
+          <li class="flex gap-3 text-sm text-text-muted">
+            <span class="text-accent mt-0.5 shrink-0">→</span>
+            <span>{n.text}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+
+    <!-- New /.well-known fields -->
+    <section class="mb-10">
+      <h2>New /.well-known/rcan-node.json Fields</h2>
+      <div class="overflow-x-auto mt-4">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-border">
+              <th class="text-left py-2 pr-4 text-text font-semibold">Field</th>
+              <th class="text-left py-2 pr-4 text-text font-semibold">Type</th>
+              <th class="text-left py-2 text-text font-semibold">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {newFields.map(f => (
+              <tr class="border-b border-border/50">
+                <td class="py-2 pr-4 font-mono text-accent text-xs">{f.field}</td>
+                <td class="py-2 pr-4 text-text-muted">{f.type}</td>
+                <td class="py-2 text-text-muted">{f.desc}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Conformance -->
+    <section class="mb-10">
+      <h2>Conformance Levels</h2>
+      <div class="overflow-x-auto mt-4">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-border">
+              <th class="text-left py-2 pr-4 text-text font-semibold">Level</th>
+              <th class="text-left py-2 pr-4 text-text font-semibold">Label</th>
+              <th class="text-left py-2 text-text font-semibold">Requirements</th>
+            </tr>
+          </thead>
+          <tbody>
+            {conformanceLevels.map(c => (
+              <tr class="border-b border-border/50">
+                <td class="py-2 pr-4 font-mono font-bold text-accent">{c.level}</td>
+                <td class="py-2 pr-4 text-text">{c.label}</td>
+                <td class="py-2 text-text-muted">{c.req}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Back -->
+    <div class="mt-12 flex flex-wrap gap-4">
+      <a href="/spec/" class="inline-flex items-center gap-2 px-6 py-3 bg-accent text-bg font-bold rounded-lg hover:bg-accent-hover transition-colors">
+        ← Full Specification
+      </a>
+      <a href="/spec/v2.2" class="inline-flex items-center gap-2 px-6 py-3 bg-bg-alt text-text border border-white/10 font-bold rounded-lg hover:border-white/20 transition-colors">
+        ← v2.2
+      </a>
+    </div>
+
+  </div>
+</DocsLayout>

--- a/tests/functions.test.ts
+++ b/tests/functions.test.ts
@@ -69,6 +69,33 @@ function parseRRN(
   return null;
 }
 
+/** Mirrors parsePqcHybridSig — parses "pqc-hybrid-v1.<ed25519_b64url>.<ml_dsa_b64url>" */
+function parsePqcHybridSig(sig: string): { ed25519: string; ml_dsa: string } | null {
+  if (!sig.startsWith("pqc-hybrid-v1.")) return null;
+  const rest = sig.slice("pqc-hybrid-v1.".length);
+  const dotIdx = rest.indexOf(".");
+  if (dotIdx < 1) return null;
+  const ed25519Part = rest.slice(0, dotIdx);
+  const mlDsaPart   = rest.slice(dotIdx + 1);
+  if (!ed25519Part || !mlDsaPart) return null;
+  // must not contain any further dots (would indicate extra segments)
+  if (mlDsaPart.includes(".")) return null;
+  return { ed25519: ed25519Part, ml_dsa: mlDsaPart };
+}
+
+/** Mirrors parsePqcV1Sig — parses "pqc-v1.<ml_dsa_b64url>" */
+function parsePqcV1Sig(sig: string): { ml_dsa: string } | null {
+  if (!sig.startsWith("pqc-v1.")) return null;
+  const mlDsaPart = sig.slice("pqc-v1.".length);
+  if (!mlDsaPart || mlDsaPart.includes(".")) return null;
+  return { ml_dsa: mlDsaPart };
+}
+
+/** Returns whether a string is a valid base64url token (no padding, URL-safe chars) */
+function isBase64url(s: string): boolean {
+  return s.length > 0 && /^[A-Za-z0-9_-]+$/.test(s);
+}
+
 /** Mirrors formatRRN from functions/api/v1/robots/index.ts */
 function formatRRN(id: number): string {
   return `RRN-${String(id).padStart(12, "0")}`;
@@ -944,5 +971,139 @@ describe("§20 Telemetry — frame structure validation", () => {
 
   it("timestamp_ms must be a number (not a string)", () => {
     expect(validateTelemetryFrame({ ...validFrame, timestamp_ms: "1710000000000" })).toBe(false);
+  });
+});
+
+// ── PQC Hybrid v1 Cryptographic Profile (issue #188) ─────────────────────────
+
+describe("pqc-hybrid-v1 signature format", () => {
+  const FAKE_ED25519  = "A".repeat(86);   // 86 base64url chars = 64 bytes (Ed25519 sig size)
+  const FAKE_ML_DSA   = "B".repeat(4412); // 4412 base64url chars = 3309 bytes (ML-DSA-65 sig size)
+  const validHybrid   = `pqc-hybrid-v1.${FAKE_ED25519}.${FAKE_ML_DSA}`;
+
+  it("parses a well-formed pqc-hybrid-v1 signature", () => {
+    const result = parsePqcHybridSig(validHybrid);
+    expect(result).not.toBeNull();
+    expect(result!.ed25519).toBe(FAKE_ED25519);
+    expect(result!.ml_dsa).toBe(FAKE_ML_DSA);
+  });
+
+  it("both components are valid base64url tokens", () => {
+    const result = parsePqcHybridSig(validHybrid)!;
+    expect(isBase64url(result.ed25519)).toBe(true);
+    expect(isBase64url(result.ml_dsa)).toBe(true);
+  });
+
+  it("rejects a bare Ed25519 sig (no prefix)", () => {
+    expect(parsePqcHybridSig(FAKE_ED25519)).toBeNull();
+  });
+
+  it("rejects a single-half sig (Ed25519 half only, no ml-dsa component)", () => {
+    expect(parsePqcHybridSig(`pqc-hybrid-v1.${FAKE_ED25519}`)).toBeNull();
+  });
+
+  it("rejects a single-half sig (empty ml-dsa component)", () => {
+    expect(parsePqcHybridSig(`pqc-hybrid-v1.${FAKE_ED25519}.`)).toBeNull();
+  });
+
+  it("rejects a single-half sig (empty ed25519 component)", () => {
+    expect(parsePqcHybridSig(`pqc-hybrid-v1..${FAKE_ML_DSA}`)).toBeNull();
+  });
+
+  it("rejects an empty string", () => {
+    expect(parsePqcHybridSig("")).toBeNull();
+  });
+
+  it("rejects wrong prefix", () => {
+    expect(parsePqcHybridSig(`pqc-v1.${FAKE_ED25519}.${FAKE_ML_DSA}`)).toBeNull();
+    expect(parsePqcHybridSig(`hybrid.${FAKE_ED25519}.${FAKE_ML_DSA}`)).toBeNull();
+  });
+
+  it("rejects extra segments (three dots = four parts)", () => {
+    expect(parsePqcHybridSig(`pqc-hybrid-v1.${FAKE_ED25519}.${FAKE_ML_DSA}.extra`)).toBeNull();
+  });
+
+  it("Ed25519 half has correct byte-size representation (86 base64url chars = 64 bytes)", () => {
+    const result = parsePqcHybridSig(validHybrid)!;
+    // base64url without padding: ceil(64 * 4 / 3) = 86 chars
+    expect(result.ed25519.length).toBe(86);
+  });
+
+  it("ML-DSA-65 half has correct byte-size representation (4412 base64url chars = 3309 bytes)", () => {
+    const result = parsePqcHybridSig(validHybrid)!;
+    // base64url without padding: ceil(3309 * 4 / 3) = 4412 chars
+    expect(result.ml_dsa.length).toBe(4412);
+  });
+});
+
+describe("pqc-v1 signature format (post-2028)", () => {
+  const FAKE_ML_DSA = "C".repeat(4412);
+  const validPqcV1  = `pqc-v1.${FAKE_ML_DSA}`;
+
+  it("parses a well-formed pqc-v1 signature", () => {
+    const result = parsePqcV1Sig(validPqcV1);
+    expect(result).not.toBeNull();
+    expect(result!.ml_dsa).toBe(FAKE_ML_DSA);
+  });
+
+  it("rejects an empty ml-dsa component", () => {
+    expect(parsePqcV1Sig("pqc-v1.")).toBeNull();
+  });
+
+  it("rejects two-component input (pqc-hybrid-v1 sig fed to pqc-v1 parser)", () => {
+    const FAKE_ED = "A".repeat(86);
+    expect(parsePqcV1Sig(`pqc-v1.${FAKE_ED}.${FAKE_ML_DSA}`)).toBeNull();
+  });
+
+  it("rejects wrong prefix", () => {
+    expect(parsePqcV1Sig(`pqc-hybrid-v1.${FAKE_ML_DSA}`)).toBeNull();
+  });
+
+  it("rejects an empty string", () => {
+    expect(parsePqcV1Sig("")).toBeNull();
+  });
+});
+
+describe("rcan-node.json manifest — PQC fields (issue #188)", () => {
+  // Mirror the updated manifest from functions/.well-known/rcan-node.json.ts
+  const manifest = {
+    rcan_node_version: "1.0",
+    node_type: "root",
+    operator: "Robot Registry Foundation",
+    namespace_prefix: "RRN",
+    public_key: null,
+    crypto_profile: "pqc-hybrid-v1",
+    pqc_public_key: null,
+    ed25519_public_key: null,
+    api_base: "https://rcan.dev/api/v1",
+    registry_ui: "https://rcan.dev/registry/",
+    spec_version: "2.3",
+    capabilities: ["register", "resolve", "verify", "delegate"],
+    sync_endpoint: "https://rcan.dev/api/v1/sync",
+    last_sync: new Date().toISOString(),
+    ttl_seconds: 3600,
+    contact: "registry@rcan.dev",
+    governance: "https://rcan.dev/governance/",
+    federation_protocol: "https://rcan.dev/federation/",
+  };
+
+  it("has crypto_profile field", () => {
+    expect(manifest).toHaveProperty("crypto_profile");
+  });
+
+  it("crypto_profile is pqc-hybrid-v1", () => {
+    expect(manifest.crypto_profile).toBe("pqc-hybrid-v1");
+  });
+
+  it("has pqc_public_key field", () => {
+    expect(manifest).toHaveProperty("pqc_public_key");
+  });
+
+  it("has ed25519_public_key field", () => {
+    expect(manifest).toHaveProperty("ed25519_public_key");
+  });
+
+  it("spec_version is 2.3", () => {
+    expect(manifest.spec_version).toBe("2.3");
   });
 });


### PR DESCRIPTION
## Summary

Defines the post-quantum cryptographic profiles for all RCAN signing surfaces, addressing the quantum threat from recent Google Quantum AI + Oratomic breakthrough papers.

## Changes

| File | Description |
|---|---|
| `docs/crypto/pqc-profile.md` | Full spec for pqc-hybrid-v1 and pqc-v1 profiles |
| `src/pages/spec/section-1.astro` | §1.6.4 PQC signing documentation |
| `functions/.well-known/rcan-node.json.ts` | Updated schema with crypto_profile, pqc_public_key, ed25519_public_key |
| `src/pages/spec/v2.3.astro` | v2.3 spec snapshot |
| `tests/functions.test.ts` | 21 new conformance tests (both halves required, reject single-half) |
| `CHANGELOG.md` + supporting files | Version bump to v2.3 |

## Profiles defined

**pqc-hybrid-v1** (recommended now): Ed25519 + ML-DSA-65, both sigs required  
**pqc-v1** (future, post-2028): ML-DSA-65 only

## Test results
122/122 passing. 89 pages build clean.

Closes #188 | Part of opencastor-ops#16 (quantum red team) implementation gate.