### PR TITLE
schemas: add version-tuple payload + hybrid envelope (Plan 1 Task 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@noble/post-quantum": "^0.6.0",
     "@types/qrcode": "^1.5.6",
     "@types/three": "^0.183.1",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "astro": "^5.18.1",
     "qrcode": "^1.5.4",
     "tailwindcss": "^3.4.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,12 @@ importers:
       '@types/three':
         specifier: ^0.183.1
         version: 0.183.1
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
       astro:
         specifier: ^5.18.1
         version: 5.18.1(@types/node@25.3.5)(jiti@1.21.7)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.3)
@@ -879,6 +885,17 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
 
@@ -1212,9 +1229,15 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1381,6 +1404,9 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -1796,6 +1822,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   require-main-filename@2.0.0:
@@ -2891,6 +2921,17 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-align@3.0.1:
     dependencies:
       string-width: 4.2.3
@@ -3311,6 +3352,8 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-deep-equal@3.1.3: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3318,6 +3361,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-uri@3.1.0: {}
 
   fastq@1.20.1:
     dependencies:
@@ -3517,6 +3562,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  json-schema-traverse@1.0.0: {}
 
   kleur@3.0.3: {}
 
@@ -4122,6 +4169,8 @@ snapshots:
       unified: 11.0.5
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   require-main-filename@2.0.0: {}
 

--- a/schemas/examples/version-tuple-envelope-robot-md.json
+++ b/schemas/examples/version-tuple-envelope-robot-md.json
@@ -1,0 +1,10 @@
+{
+  "ran": "RAN-000000000002",
+  "alg": ["ML-DSA-65", "Ed25519"],
+  "pq_kid": "deadbeef",
+  "kid": "cafebabe",
+  "payload": "eyJkZXBlbmRzX29uIjp7Im1hbmlmZXN0X3NwZWNfdmVyc2lvbiI6Ij09MS41LjAiLCJwcm90b2NvbF92ZXJzaW9uIjoiPj0zLjIuMCJ9LCJmaWVsZCI6ImNsaV92ZXJzaW9uIiwibWF0cml4X3ZlcnNpb24iOiIxLjAiLCJwcm9qZWN0Ijoicm9ib3QtbWQiLCJyZWxlYXNlZF9hdCI6IjIwMjYtMDUtMDFUMTc6NDI6MTFaIiwidmFsdWUiOiIxLjUuMCJ9",
+  "signature_mldsa65": "AAAAplaceholderShape",
+  "signature_ed25519": "BBBBplaceholderShape",
+  "signed_at": "2026-05-01T17:42:15Z"
+}

--- a/schemas/examples/version-tuple-robot-md.json
+++ b/schemas/examples/version-tuple-robot-md.json
@@ -1,0 +1,11 @@
+{
+  "project": "robot-md",
+  "matrix_version": "1.0",
+  "field": "cli_version",
+  "value": "1.5.0",
+  "depends_on": {
+    "protocol_version": ">=3.2.0",
+    "manifest_spec_version": "==1.5.0"
+  },
+  "released_at": "2026-05-01T17:42:11Z"
+}

--- a/schemas/version-tuple-envelope.json
+++ b/schemas/version-tuple-envelope.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rcan.dev/schemas/version-tuple-envelope.json",
+  "title": "RCAN Compatibility Matrix — version tuple ENVELOPE (hybrid-signed wrapper)",
+  "description": "Signed wrapper around a version-tuple payload. Per RCAN v3.2 Decision 3 (pqc-hybrid-v1, PQ-required-classical-optional): signature_mldsa65 is REQUIRED; signature_ed25519 is OPTIONAL but if present must verify and must be paired with `kid`.",
+  "type": "object",
+  "required": ["ran", "alg", "pq_kid", "payload", "signature_mldsa65", "signed_at"],
+  "additionalProperties": false,
+  "properties": {
+    "ran": {
+      "type": "string",
+      "description": "RAN of the signing authority. Resolves to /v2/authorities/<ran> for public-key lookup.",
+      "pattern": "^RAN-[0-9]{12}$"
+    },
+    "alg": {
+      "type": "array",
+      "description": "Signature algorithms present, in order. Index 0 is always ML-DSA-65 (required); index 1 is Ed25519 if signature_ed25519 is present.",
+      "items": { "type": "string", "enum": ["ML-DSA-65", "Ed25519"] },
+      "minItems": 1,
+      "maxItems": 2,
+      "prefixItems": [
+        { "const": "ML-DSA-65" }
+      ]
+    },
+    "pq_kid": {
+      "type": "string",
+      "description": "ML-DSA-65 key id, derived as sha256(pq_pub)[:8].hex(). Must match pq_kid stored on /v2/authorities/<ran>.",
+      "pattern": "^[0-9a-f]{8,}$"
+    },
+    "kid": {
+      "type": "string",
+      "description": "Optional Ed25519 key id. Only present when signature_ed25519 is present.",
+      "pattern": "^[0-9a-f]{8,}$"
+    },
+    "payload": {
+      "type": "string",
+      "description": "Base64-encoded canonical-JSON of the inner version-tuple payload (sorted keys, no whitespace, UTF-8).",
+      "contentEncoding": "base64"
+    },
+    "signature_mldsa65": {
+      "type": "string",
+      "description": "Base64-encoded ML-DSA-65 signature over the b64-decoded payload bytes. Verified against /v2/authorities/<ran>.pq_signing_pub.",
+      "contentEncoding": "base64"
+    },
+    "signature_ed25519": {
+      "type": "string",
+      "description": "Optional. Base64-encoded Ed25519 signature over the same b64-decoded payload bytes. Verified against /v2/authorities/<ran>.signing_pub. If present, MUST verify; absent is OK.",
+      "contentEncoding": "base64"
+    },
+    "signed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC 3339 UTC timestamp of when the envelope was signed."
+    }
+  },
+  "dependentRequired": {
+    "signature_ed25519": ["kid"]
+  }
+}

--- a/schemas/version-tuple.json
+++ b/schemas/version-tuple.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rcan.dev/schemas/version-tuple.json",
+  "title": "RCAN Compatibility Matrix — version tuple PAYLOAD (single project assertion)",
+  "description": "Inner payload of a per-project signed assertion. Wrapped by version-tuple-envelope.json. Aggregated daily into the compatibility matrix at /v2/compatibility-matrix.",
+  "type": "object",
+  "required": ["project", "matrix_version", "field", "value", "depends_on", "released_at"],
+  "additionalProperties": false,
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "Stable project slug, e.g. 'robot-md', 'rcan-py', 'opencastor'. Resolves to a RAN via opencastor-ops/config/repos.json.",
+      "pattern": "^[a-z][a-z0-9-]+$"
+    },
+    "matrix_version": {
+      "type": "string",
+      "description": "Version of the matrix schema this tuple targets.",
+      "const": "1.0"
+    },
+    "field": {
+      "type": "string",
+      "description": "Which row in the canonical tuple this assertion populates.",
+      "enum": [
+        "manifest_spec_version",
+        "cli_version",
+        "mcp_bridge_version",
+        "gateway_version",
+        "protocol_version",
+        "sdk_version_py",
+        "sdk_version_ts",
+        "registry_api_version",
+        "runtime_version",
+        "certification_suite_version"
+      ]
+    },
+    "value": {
+      "type": "string",
+      "description": "Asserted value. Semver for code projects; profile string for protocol/cert."
+    },
+    "depends_on": {
+      "type": "object",
+      "description": "Range constraints this release expects of other rows.",
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^(==|>=|<=|>|<|~|\\^)?[0-9]+\\.[0-9]+\\.[0-9]+$"
+      },
+      "properties": {
+        "protocol_version": {
+          "type": "string",
+          "pattern": "^(==|>=|<=|>|<|~|\\^)?[0-9]+\\.[0-9]+\\.[0-9]+$"
+        }
+      }
+    },
+    "released_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC 3339 UTC timestamp."
+    }
+  }
+}

--- a/tests/version-tuple-schema.test.ts
+++ b/tests/version-tuple-schema.test.ts
@@ -1,0 +1,190 @@
+/**
+ * rcan-spec — Vitest schema validation tests for version-tuple JSON Schemas
+ *
+ * Covers:
+ *   - Payload schema (version-tuple.json): required fields, enum values, pattern constraints
+ *   - Envelope schema (version-tuple-envelope.json): hybrid sig shape, PQ-required classical-optional
+ *
+ * Per RCAN v3.2 Decision 3 (pqc-hybrid-v1):
+ *   - signature_mldsa65 + pq_kid are REQUIRED
+ *   - signature_ed25519 + kid are OPTIONAL, but if ed25519 is present, kid must also be present
+ *
+ * Uses AJV 2020-12 for JSON Schema 2020-12 support (prefixItems, dependentRequired).
+ * Existing draft-07 schemas are NOT touched.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+// ── Schema + fixture loading ──────────────────────────────────────────────────
+
+const root = resolve(import.meta.dirname ?? ".", "..");
+
+const PAYLOAD_SCHEMA = JSON.parse(
+  readFileSync(resolve(root, "schemas/version-tuple.json"), "utf-8")
+);
+const ENVELOPE_SCHEMA = JSON.parse(
+  readFileSync(resolve(root, "schemas/version-tuple-envelope.json"), "utf-8")
+);
+const PAYLOAD_EX = JSON.parse(
+  readFileSync(resolve(root, "schemas/examples/version-tuple-robot-md.json"), "utf-8")
+);
+const ENVELOPE_EX = JSON.parse(
+  readFileSync(
+    resolve(root, "schemas/examples/version-tuple-envelope-robot-md.json"),
+    "utf-8"
+  )
+);
+
+// ── AJV setup ─────────────────────────────────────────────────────────────────
+
+function makeAjv(): InstanceType<typeof Ajv2020> {
+  const ajv = new Ajv2020({ strict: false, allErrors: true });
+  addFormats(ajv);
+  return ajv;
+}
+
+// Validate helper — returns list of error message strings
+function errorsFor(schema: object, data: unknown): string[] {
+  const ajv = makeAjv();
+  const valid = ajv.validate(schema, data);
+  if (valid) return [];
+  return (ajv.errors ?? []).map((e) => JSON.stringify(e));
+}
+
+// ── Schema meta-validation ────────────────────────────────────────────────────
+
+describe("Schema meta-validation", () => {
+  it("payload schema is valid JSON Schema 2020-12", () => {
+    const ajv = makeAjv();
+    expect(() => ajv.addSchema(PAYLOAD_SCHEMA)).not.toThrow();
+  });
+
+  it("envelope schema is valid JSON Schema 2020-12", () => {
+    const ajv = makeAjv();
+    expect(() => ajv.addSchema(ENVELOPE_SCHEMA)).not.toThrow();
+  });
+});
+
+// ── Payload example validation ────────────────────────────────────────────────
+
+describe("Payload example", () => {
+  it("payload example validates against payload schema", () => {
+    const errors = errorsFor(PAYLOAD_SCHEMA, PAYLOAD_EX);
+    expect(errors).toEqual([]);
+  });
+});
+
+// ── Envelope example validation ───────────────────────────────────────────────
+
+describe("Envelope example", () => {
+  it("envelope example validates against envelope schema", () => {
+    const errors = errorsFor(ENVELOPE_SCHEMA, ENVELOPE_EX);
+    expect(errors).toEqual([]);
+  });
+});
+
+// ── Payload required fields ───────────────────────────────────────────────────
+
+describe("Payload required fields", () => {
+  it("rejects payload missing released_at", () => {
+    const { released_at: _r, ...bad } = PAYLOAD_EX;
+    const errors = errorsFor(PAYLOAD_SCHEMA, bad);
+    expect(errors.some((e) => e.includes("released_at"))).toBe(true);
+  });
+
+  it("rejects payload with invalid protocol_version format in depends_on", () => {
+    // "v3.2" is not valid semver (has 'v' prefix, missing patch)
+    const bad = {
+      ...PAYLOAD_EX,
+      depends_on: { protocol_version: "v3.2", manifest_spec_version: "==1.5.0" },
+    };
+    const errors = errorsFor(PAYLOAD_SCHEMA, bad);
+    expect(errors.some((e) => e.includes("protocol_version"))).toBe(true);
+  });
+});
+
+// ── Envelope signature requirements ──────────────────────────────────────────
+
+describe("Envelope — PQ signature requirements", () => {
+  it("rejects envelope missing signature_mldsa65", () => {
+    const { signature_mldsa65: _s, ...bad } = ENVELOPE_EX;
+    const errors = errorsFor(ENVELOPE_SCHEMA, bad);
+    expect(errors.some((e) => e.includes("signature_mldsa65"))).toBe(true);
+  });
+
+  it("rejects envelope missing pq_kid", () => {
+    const { pq_kid: _k, ...bad } = ENVELOPE_EX;
+    const errors = errorsFor(ENVELOPE_SCHEMA, bad);
+    expect(errors.some((e) => e.includes("pq_kid"))).toBe(true);
+  });
+
+  it("PQ-only envelope (no kid + no ed25519 sig) validates", () => {
+    const pqOnly = { ...ENVELOPE_EX };
+    delete (pqOnly as Record<string, unknown>).kid;
+    delete (pqOnly as Record<string, unknown>).signature_ed25519;
+    const errors = errorsFor(ENVELOPE_SCHEMA, pqOnly);
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects envelope with signature_ed25519 but no kid (dependentRequired)", () => {
+    const { kid: _k, ...bad } = ENVELOPE_EX;
+    // ENVELOPE_EX has both kid and signature_ed25519; removing kid should fail
+    const errors = errorsFor(ENVELOPE_SCHEMA, bad);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Envelope RAN format ───────────────────────────────────────────────────────
+
+describe("Envelope — RAN format", () => {
+  it("rejects envelope with malformed ran", () => {
+    const bad = { ...ENVELOPE_EX, ran: "not-a-ran" };
+    const errors = errorsFor(ENVELOPE_SCHEMA, bad);
+    expect(errors.some((e) => e.toLowerCase().includes("ran"))).toBe(true);
+  });
+});
+
+// ── Envelope alg array constraints ───────────────────────────────────────────
+
+describe("Envelope — alg array", () => {
+  it("rejects alg where first item is not ML-DSA-65 (prefixItems)", () => {
+    const bad = { ...ENVELOPE_EX, alg: ["Ed25519", "ML-DSA-65"] };
+    const errors = errorsFor(ENVELOPE_SCHEMA, bad);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Payload base64 round-trip ─────────────────────────────────────────────────
+
+describe("Payload base64 round-trip", () => {
+  it("envelope.payload decodes to canonical-JSON of the payload fixture", () => {
+    const decoded = Buffer.from(ENVELOPE_EX.payload, "base64").toString("utf-8");
+    const expected = JSON.stringify(PAYLOAD_EX, Object.keys(PAYLOAD_EX).sort(), undefined)
+      .replace(/\s/g, "");
+    // Canonical JSON: sorted keys, no whitespace
+    const expectedCanonical = JSON.stringify(
+      JSON.parse(JSON.stringify(PAYLOAD_EX)),
+      (_, v) => v,
+      0
+    );
+    // Use sort_keys canonical form matching Python's json.dumps(sort_keys=True, separators=(',',':'))
+    function sortedStringify(obj: unknown): string {
+      if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+        return JSON.stringify(obj);
+      }
+      const sorted: Record<string, unknown> = {};
+      for (const key of Object.keys(obj as object).sort()) {
+        sorted[key] = (obj as Record<string, unknown>)[key];
+      }
+      return `{${Object.entries(sorted)
+        .map(([k, v]) => `${JSON.stringify(k)}:${sortedStringify(v)}`)
+        .join(",")}}`;
+    }
+    const canonical = sortedStringify(PAYLOAD_EX);
+    expect(decoded).toBe(canonical);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `schemas/version-tuple.json` — inner payload schema for per-project release assertions (project slug, field, value, depends_on, released_at)
- Adds `schemas/version-tuple-envelope.json` — hybrid-signed wrapper per RCAN v3.2 Decision 3 (`pqc-hybrid-v1`, PQ-required-classical-optional): `pq_kid` + `signature_mldsa65` REQUIRED; `kid` + `signature_ed25519` OPTIONAL via `dependentRequired`
- Adds example fixtures + 13 vitest tests (AJV 2020-12) covering schema meta-validation, required fields, envelope sig constraints, RAN format, `prefixItems` alg ordering, and base64 round-trip

## Design decisions

- **Two-schema split** per Decision 3 (PR #200): payload carries the assertion; envelope carries the signed+base64-wrapped payload + RAN identifier + hybrid sigs
- **`prefixItems: [{const: "ML-DSA-65"}]`** enforces ML-DSA-65 is always at index 0 in `alg` array
- **`dependentRequired: {signature_ed25519: ["kid"]}`** enforces classical key id is required when classical signature is present
- **Existing draft-07 schemas untouched** — 2020-12 migration is a follow-up issue per task spec
- **Placeholder signatures** in fixture: non-empty base64 strings that pass schema shape validation; cryptographic verification is Task 7

## Test plan

- [x] 13 new tests pass: `npx vitest run tests/version-tuple-schema.test.ts`
- [x] 169 total tests pass: `npx vitest run`
- [x] Astro build clean: 99 pages built
- [x] `payload` base64 in envelope fixture round-trips to canonical-JSON of payload fixture
- [x] Branch: `feat/version-tuple-schemas`, base: `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)