### PR TITLE
fix(emit-version-tuple): namespace output filename by field

### DIFF
--- a/.github/actions/emit-version-tuple/README.md
+++ b/.github/actions/emit-version-tuple/README.md
@@ -25,7 +25,9 @@ Drop `ed25519_signing_key` and `ed25519_kid`. Envelope ships PQ-only; verifiers 
 
 ## Output
 
-`version-tuple-envelope.json` attached to the release. Aggregated daily by `opencastor-ops/monitor/version_matrix.py` after PQ verification (and classical if present) against `/v2/authorities/<ran>`.
+For each call, attaches `version-tuple-envelope-<field>.json` to the GitHub release (e.g. `version-tuple-envelope-cli_version.json` for a `cli_version` assertion). Aggregated daily by `opencastor-ops/monitor/version_matrix.py` after PQ verification (and classical if present) against `/v2/authorities/<ran>`.
+
+A project that asserts multiple fields (e.g. `cli_version` + `manifest_spec_version`) calls the action once per field; each call produces its own file.
 
 Schemas:
 - Payload: `schemas/version-tuple.json`

--- a/.github/actions/emit-version-tuple/action.yml
+++ b/.github/actions/emit-version-tuple/action.yml
@@ -81,18 +81,20 @@ runs:
         if [ -f "$RUNNER_TEMP/ed.priv.pem" ]; then
           ED_ARGS="--ed-key $RUNNER_TEMP/ed.priv.pem --ed-kid ${{ inputs.ed25519_kid }}"
         fi
+        ENV_FILE="$RUNNER_TEMP/version-tuple-envelope-${{ inputs.field }}.json"
         python3 ${{ github.action_path }}/sign_envelope.py \
           --payload "$RUNNER_TEMP/payload.json" \
           --ran    "${{ inputs.ran }}" \
           --pq-key "$RUNNER_TEMP/pq.priv.bin" \
           --pq-kid "${{ inputs.pq_kid }}" \
           $ED_ARGS \
-          --out    "$RUNNER_TEMP/version-tuple-envelope.json"
+          --out    "$ENV_FILE"
+        echo "ENV_FILE=$ENV_FILE" >> "$GITHUB_ENV"
     - name: Attach to release
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
         gh release upload "${{ inputs.release_tag }}" \
-          "$RUNNER_TEMP/version-tuple-envelope.json" \
+          "$ENV_FILE" \
           --clobber


### PR DESCRIPTION
## Summary

Phase 2 prereq for Plan 1 of the OpenCastor ecosystem direction.

Without this fix, a project calling the action twice on the same release (e.g. `cli_version` + `manifest_spec_version`) clobbers its own first emit. Output filename is now `version-tuple-envelope-<field>.json`.

- `action.yml`: introduces `ENV_FILE` variable set to `$RUNNER_TEMP/version-tuple-envelope-${{ inputs.field }}.json`; passes `$ENV_FILE` to both the `--out` argument and `gh release upload`
- `README.md`: Output section updated to reflect the new `version-tuple-envelope-<field>.json` pattern and multi-field usage

## Test plan

- [x] Existing 8 pytest tests pass (`pytest .github/actions/emit-version-tuple/tests/ -v`)
- [x] Only `action.yml` and `README.md` modified — no library, schema, or fixture changes
- [ ] After merge: retag the spec repo at `v3.2.1` so consumers can pin to a stable point; existing `@v3.2.0` consumers keep working until they upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)