### PR TITLE
docs: Plan 2 Phase 2 — rcan-spec/rcan.dev wording pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 **Current canonical version:** see [`rcan.dev/compatibility`](https://rcan.dev/compatibility) (live matrix, signed daily by the OpenCastor compatibility-matrix aggregator — RAN registered at robotregistryfoundation.org).
 
-[![Spec Version](https://img.shields.io/badge/spec-v3.2-blue)](https://rcan.dev/spec/)
+[![Spec](https://img.shields.io/badge/spec-live%20matrix-blue)](https://rcan.dev/compatibility)
 [![License](https://img.shields.io/badge/license-CC%20BY%204.0-green)](https://creativecommons.org/licenses/by/4.0/)
 [![CI](https://github.com/continuonai/rcan-spec/actions/workflows/ci.yml/badge.svg)](https://github.com/continuonai/rcan-spec/actions)
 
-**[→ Read the spec at rcan.dev/spec/](https://rcan.dev/spec/)**
+**[→ Read the spec at rcan.dev/spec/](https://rcan.dev/spec/) · [→ Live compatibility matrix](https://rcan.dev/compatibility)**
+
+<!-- BEGIN: ecosystem certification disclaimer (canonical, derived from spec §10) -->
+> **Conformance is not certification.**
+>
+> Conformance to RCAN tracks (L1–L4 protocol, Gateway Authority, HIL Runtime Safety) is *self-asserted via signed bundles* and *independently replayable from those bundles*. Conformance is not certification. Certification requires audit by a qualified third-party body, which is intentionally out-of-scope for the foundation in 2026.
+<!-- END: ecosystem certification disclaimer -->
 
 ## Where this fits in the stack
 
@@ -81,7 +87,7 @@ RCAN defines the *wire* layer (how robots talk). A robot still needs a way to de
 |---|---|---|
 | [**ROBOT.md**](https://robotmd.dev) | Single-file robot manifest (YAML frontmatter + markdown prose) — read by any agent harness (Claude Code, ChatGPT, Gemini, Ollama, …) at session start so the planner knows the robot before the first prompt. Uses `rcan_version` in the frontmatter to pin its RCAN target. | [RobotRegistryFoundation/robot-md](https://github.com/RobotRegistryFoundation/robot-md) |
 
-ROBOT.md is independent of RCAN — you can ship one without the other — but the two compose cleanly: a robot with a ROBOT.md that pins `rcan_version: "3.0"` speaks RCAN 3.0 on the wire and declares that fact in its manifest.
+ROBOT.md is independent of RCAN — you can ship one without the other — but the two compose cleanly: a robot with a ROBOT.md that pins `rcan_version` speaks the [RCAN protocol](https://rcan.dev/spec/) on the wire at the pinned version and declares that fact in its manifest.
 
 ## Conformance Badges
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repo is the **wire-protocol specification** of a small, composable, Apache/
 | **Python SDK** | [rcan-py](https://github.com/continuonai/rcan-py) | `pip install rcan` — RCANMessage, RobotURI, ConfidenceGate, HiTLGate, AuditChain. |
 | **TypeScript SDK** | [rcan-ts](https://github.com/continuonai/rcan-ts) | `npm install rcan-ts` — same API surface for Node + browser. |
 | **Registry** | [Robot Registry Foundation](https://robotregistryfoundation.org) | Permanent RRN identities. Public resolver at `/r/<rrn>`. Like ICANN for robots. |
-| **Reference runtime** | [OpenCastor](https://github.com/craigm26/OpenCastor) | Open-source robot runtime — connects LLM brains to hardware bodies. One implementation of RCAN. |
+| **Productized runtime (Layer 4)** | [OpenCastor](https://github.com/craigm26/OpenCastor) | Open-source productized RCAN runtime — connects LLM brains to hardware bodies. One implementation of RCAN. |
 
 ## What Problem RCAN Solves
 
@@ -77,7 +77,7 @@ Robots today are islands. A Boston Dynamics Spot and a Raspberry Pi rover can't 
 |---|---|---|---|
 | [rcan-py](https://github.com/continuonai/rcan-py) | Python 3.10+ | `pip install rcan` | 754 |
 | [rcan-ts](https://github.com/continuonai/rcan-ts) | TypeScript / Node 18+ | `npm install rcan-ts` | 447 |
-| [OpenCastor](https://github.com/craigm26/OpenCastor) | Python (robot runtime) | `pip install opencastor==2026.3.17.1` | 6,459 |
+| [OpenCastor](https://github.com/craigm26/OpenCastor) | Python (robot runtime) | `pip install opencastor` | 6,459 |
 
 ## Companion formats
 
@@ -104,16 +104,9 @@ Conformance tests live in the [`tests/`](tests/) directory and run against a ref
 
 ## Spec Versioning
 
-RCAN follows a **major.minor** policy. The spec is versioned independently of any SDK.
+RCAN follows a **major.minor** policy. The spec is versioned independently of any SDK. Minor bumps add fields and message types; they never remove or rename existing ones — newer SDKs can read older messages.
 
-| Spec | SDKs | Backward compatible? |
-|---|---|---|
-| v1.6 | rcan-py 0.6, rcan-ts 0.6, OpenCastor 2026.4 | ✅ Yes |
-| v1.5 | rcan-py 0.5, rcan-ts 0.5 | ✅ Yes |
-| v1.4 | rcan-py 0.4, rcan-ts 0.4 | ✅ Yes |
-| v1.0–1.3 | Legacy | ✅ Yes (message envelope backward compat) |
-
-Minor bumps add fields and message types; they never remove or rename existing ones. A v1.6 SDK can read v1.0 messages.
+For active spec/SDK pairings, see the [live compatibility matrix](https://rcan.dev/compatibility). Full version history at [rcan.dev/changelog](https://rcan.dev/changelog).
 
 ## Contributing to the Spec
 
@@ -130,15 +123,17 @@ Open issues and proposals at [github.com/continuonai/rcan-spec/issues](https://g
 
 ## Ecosystem
 
-| Package | Version | Purpose |
-|---|---|---|
-| **rcan-spec** (this) | v1.6.0 | Protocol specification |
-| [rcan-py](https://github.com/continuonai/rcan-py) | v0.6.0 | Python SDK |
-| [rcan-ts](https://github.com/continuonai/rcan-ts) | v0.6.0 | TypeScript SDK |
-| [OpenCastor](https://github.com/craigm26/OpenCastor) | v2026.3.17.1 | Robot runtime (reference impl) |
-| [RRF](https://robotregistryfoundation.org) | v1.6.0 | Robot identity registry |
-| [Fleet UI](https://app.opencastor.com) | live | Web fleet dashboard |
-| [Docs](https://docs.opencastor.com) | live | Runtime reference, RCAN, API |
+| Package | Purpose |
+|---|---|
+| **rcan-spec** (this) | Protocol specification |
+| [rcan-py](https://github.com/continuonai/rcan-py) | Python SDK |
+| [rcan-ts](https://github.com/continuonai/rcan-ts) | TypeScript SDK |
+| [OpenCastor](https://github.com/craigm26/OpenCastor) | Productized robot runtime (Layer 4) |
+| [RRF](https://robotregistryfoundation.org) | Robot identity registry |
+| [Fleet UI](https://app.opencastor.com) | Web fleet dashboard |
+| [Docs](https://docs.opencastor.com) | Runtime reference, RCAN, API |
+
+Current versions for all packages: see the [live compatibility matrix](https://rcan.dev/compatibility).
 
 ## License
 

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -1,5 +1,29 @@
 ---
 import InteractiveNetwork from './InteractiveNetwork.astro';
+
+// SSR fetch the live compatibility matrix at build time.
+// Falls back to a non-versioned label if the endpoint is unreachable
+// or returns an unexpected shape.
+let protocolLabel = 'live compatibility matrix';
+try {
+  const response = await fetch('https://robotregistryfoundation.org/v2/compatibility-matrix', {
+    headers: { 'Accept': 'application/json' },
+  });
+  if (response.ok) {
+    const envelope = await response.json();
+    if (envelope?.payload) {
+      const decoded = JSON.parse(
+        Buffer.from(envelope.payload, 'base64url').toString('utf-8')
+      );
+      const version = decoded?.projects?.['rcan-spec']?.fields?.protocol_version?.value;
+      if (version) {
+        protocolLabel = `RCAN ${version} · matrix-driven`;
+      }
+    }
+  }
+} catch {
+  // network or shape errors are non-fatal; ship the neutral label
+}
 ---
 <section class="relative py-20 lg:py-32 overflow-hidden min-h-[90vh] flex items-center justify-center">
   <!-- Dynamic Background -->
@@ -10,7 +34,7 @@ import InteractiveNetwork from './InteractiveNetwork.astro';
   <div class="relative z-20 text-center max-w-5xl mx-auto px-6">
     <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/5 border border-white/10 text-xs font-medium text-text-muted mb-8 animate-fade-in opacity-0 backdrop-blur-md" style="animation-delay: 0.1s">
       <span class="w-2 h-2 rounded-full bg-accent animate-pulse"></span>
-      v1.3 — Whole Solution Release
+      <a href="/compatibility" class="hover:underline">{protocolLabel}</a>
     </div>
 
     <h1 class="text-6xl lg:text-8xl font-bold tracking-tight mb-8 animate-fade-in opacity-0" style="animation-delay: 0.2s">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -101,6 +101,24 @@ const tsBadge = sdkBadge('rcan-ts');
     </div>
   </section>
 
+  <section class="max-w-5xl mx-auto py-24 border-b border-white/5 px-6">
+    <div class="text-center mb-12">
+      <p class="text-sm font-mono uppercase tracking-widest text-accent mb-4">Six layers, one job each</p>
+      <h2 class="text-3xl md:text-4xl font-bold mb-4">Where RCAN sits</h2>
+      <p class="text-xl text-text-muted max-w-2xl mx-auto">
+        RCAN is Layer 5 — the wire protocol. It does not enforce. It does not run. It specifies.
+      </p>
+    </div>
+    <ol class="space-y-3 text-sm text-text-muted max-w-3xl mx-auto">
+      <li><strong class="text-white">Layer 1 — Declaration.</strong> ROBOT.md, robot-md CLI, robot-md-mcp (Advisory).</li>
+      <li><strong class="text-white">Layer 2 — Agent runtime.</strong> Claude Code, Codex, Gemini, any MCP host.</li>
+      <li><strong class="text-white">Layer 3 — Gateway / Enforcement.</strong> robot-md-gateway. Mandatory exclusive path.</li>
+      <li><strong class="text-white">Layer 4 — Robot-facing runtime.</strong> OpenCastor and other RCAN runtimes.</li>
+      <li><strong class="text-white">Layer 5 — Protocol.</strong> RCAN spec + SDKs. <em>This site.</em></li>
+      <li><strong class="text-white">Layer 6 — Registry.</strong> Robot Registry Foundation.</li>
+    </ol>
+  </section>
+
   <section class="py-24 border-b border-white/5">
     <div class="max-w-7xl mx-auto">
       <h2 class="text-3xl md:text-4xl font-bold mb-4 text-center">Protocol Features</h2>
@@ -178,7 +196,7 @@ const tsBadge = sdkBadge('rcan-ts');
           <div class="w-12 h-12 mb-6 rounded-xl bg-accent/10 border border-accent/20 flex items-center justify-center text-2xl">🏛️</div>
           <h3 class="text-xl font-bold mb-3 group-hover:text-accent transition-colors">Governments & Regulators</h3>
           <p class="text-text-muted text-sm leading-relaxed">
-            An open specification under independent governance, with a built-in AI accountability layer and SBOM-equipped reference implementation — designed for regulatory review and adoption.
+            Audit an open specification under independent governance, with a built-in AI accountability layer and signed audit chain. Productized runtimes (e.g., OpenCastor, robot-md) ship as Layer 4 with SBOM and conformance reports — useful inputs for regulatory and procurement review.
           </p>
         </div>
       </div>
@@ -441,5 +459,14 @@ if gate.allows(confidence):
         Open specification · CC BY 4.0 · No vendor lock-in · <a href="/changelog/" class="underline hover:text-text-muted/80 transition-colors">Changelog</a>
       </p>
     </div>
+  </section>
+
+  <section class="max-w-3xl mx-auto py-12 px-6">
+    <!-- BEGIN: ecosystem certification disclaimer (canonical, derived from spec §10) -->
+    <blockquote class="border-l-4 border-accent/30 pl-6 text-text-muted">
+      <strong class="text-white">Conformance is not certification.</strong><br />
+      Conformance to RCAN tracks (L1–L4 protocol, Gateway Authority, HIL Runtime Safety) is <em>self-asserted via signed bundles</em> and <em>independently replayable from those bundles</em>. Conformance is not certification. Certification requires audit by a qualified third-party body, which is intentionally out-of-scope for the foundation in 2026.
+    </blockquote>
+    <!-- END: ecosystem certification disclaimer -->
   </section>
 </BaseLayout>


### PR DESCRIPTION
## Summary

Phase 2 of [Plan 2 (Documentation Accuracy)](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/plans/2026-05-04-documentation-accuracy.md). Retires hardcoded version strings and "reference runtime" framing from rcan-spec's user-facing surfaces. Embeds the canonical certification disclaimer.

### What changed

- **`src/components/HeroSection.astro`** (Task 11): hardcoded `v1.3 — Whole Solution Release` badge replaced with a build-time SSR fetch of the live compatibility matrix at `https://robotregistryfoundation.org/v2/compatibility-matrix`. Decodes the signed envelope's base64url payload and reads `projects['rcan-spec'].fields.protocol_version.value`. Falls back to `live compatibility matrix` on network/shape failures. Hero now renders `RCAN 3.2.1 · matrix-driven` from the live envelope.
- **`src/pages/index.astro`** (Task 12): added "Where RCAN sits" six-layer summary section (per spec §2). Rewrote Governments & Regulators persona card to drop "reference implementation" framing (spec §3 Decision 2: RCAN is implementation-independent). Embedded canonical certification disclaimer with `<!-- BEGIN/END -->` markers.
- **`README.md`** (Task 13): replaced hardcoded `spec-v3.2` badge with `spec-live matrix` linked to `rcan.dev/compatibility`. Added "Live compatibility matrix" footer link. Embedded certification disclaimer above "## Where this fits in the stack". Reworded the ROBOT.md ↔ RCAN composition paragraph from `RCAN 3.0` to a matrix-link pattern.
- **`README.md` again** (Task 13b): retired the stale `## Spec Versioning` table (was 2 majors stale at v1.6) → link-out to changelog + matrix. Dropped the Version column from the `## Ecosystem` table (versions live in the matrix). Renamed `Reference runtime` → `Productized runtime (Layer 4)` in two places. Dropped `==2026.3.17.1` pin from the OpenCastor install line.

### GitHub About field

Set to: `RCAN — open protocol for robot communication and addressing. Spec + conformance suite. See live versions at rcan.dev/compatibility.`

### Spec references

- §8 (no hardcoded RCAN/spec versions on marketing surfaces)
- §10 (Honesty Appendix — certification disclaimer canonical text)
- §3 Decision 2 (RCAN is implementation-independent; OpenCastor is one productized Layer 4 runtime, not "the" reference)
- §2 (six-layer architecture)

### Verification

- [x] `forbidden-phrase-lint` runs clean on all 4 touched files (`README.md`, `src/pages/index.astro`, `src/components/HeroSection.astro` — verified via `python tools/lint_forbidden_phrases.py --root <file>`).
- [x] `npm run build` clean (99 pages, 16s).
- [x] `npx vitest run tests/functions.test.ts` 156/156 passed.
- [x] Hero badge renders the live `RCAN 3.2.1 · matrix-driven` value from the matrix endpoint at build time (verified by inspecting `dist/index.html`).

## Test plan

- [ ] Cloudflare Pages preview deploy renders the hero badge with the dynamic `RCAN <ver> · matrix-driven` label
- [ ] Cert disclaimer appears as the last section before the footer on `/` (rendered version)
- [ ] "Where RCAN sits" section visually flows with adjacent sections
- [ ] No regression on existing pages (changelog, spec, conformance, etc. — those will be addressed in Phase 2.5)

## Phase 2.5 follow-up (deferred from this PR)

This PR scoped to the index page + hero + README. A separate Phase 2.5 will land in 3 PRs:
1. **opencastor-ops dict allowlist update** for rcan-spec's legitimate version surfaces (`src/pages/spec/`, `src/pages/changelog.astro`, `docs/v*-tracking.md`, `docs/v*-planning.md`, `docs/roadmap/`, `docs/compliance/conformity-assessment-template.md`, `docs/whitepaper/`).
2. **rcan-spec wording fixes** for ~30 real marketing-surface hits across `src/pages/safety.astro`, `quickstart.astro`, `governance.astro`, `implementations/index.astro`, `src/pages/docs/*`, `src/components/SiteHeader.astro`, `SiteFooter.astro`.
3. **`forbidden-phrase-lint.yml`** added to `.github/workflows/` + `OPENCASTOR_OPS_READ_TOKEN` secret provisioned. Reuses the inline-form template from `RobotRegistryFoundation/robot-md/.github/workflows/forbidden-phrase-lint.yml`.

Phase 2.5 must close before Phase 3 (RRF) so the canonical CI pattern is proven across multiple consumer repos.

## Refs

- Plan: [2026-05-04-documentation-accuracy.md Tasks 11-13 (+13b)](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/plans/2026-05-04-documentation-accuracy.md)
- Phase 0 close: opencastor-ops master `4b45b33`
- Phase 1 close: robot-md main `2548191` (PR #40)