### PR TITLE
ci: Plan 2 Phase 2.5 — wire forbidden-phrase-lint workflow

### DIFF
--- a/.github/workflows/forbidden-phrase-lint.yml
+++ b/.github/workflows/forbidden-phrase-lint.yml
@@ -1,0 +1,50 @@
+name: forbidden-phrase-lint
+
+on:
+  pull_request:
+    paths:
+      - 'README.md'
+      - 'SECURITY.md'
+      - 'CHANGELOG.md'
+      - 'VERSIONING.md'
+      - 'src/**'
+      - 'docs/**'
+      - '.github/workflows/forbidden-phrase-lint.yml'
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Fetch lint + dictionary from opencastor-ops
+        env:
+          AUTH_TOKEN: ${{ secrets.OPENCASTOR_OPS_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          API="https://api.github.com/repos/craigm26/opencastor-ops/contents"
+          REF="master"
+          mkdir -p .forbidden-phrase-lint
+          curl -fsSL \
+            -H "Authorization: Bearer ${AUTH_TOKEN}" \
+            -H "Accept: application/vnd.github.raw" \
+            "${API}/tools/lint_forbidden_phrases.py?ref=${REF}" \
+            -o .forbidden-phrase-lint/lint.py
+          curl -fsSL \
+            -H "Authorization: Bearer ${AUTH_TOKEN}" \
+            -H "Accept: application/vnd.github.raw" \
+            "${API}/docs/standards/forbidden-phrases.json?ref=${REF}" \
+            -o .forbidden-phrase-lint/dict.json
+      - name: Run lint
+        run: |
+          set -euo pipefail
+          python .forbidden-phrase-lint/lint.py \
+            --dict .forbidden-phrase-lint/dict.json \
+            --root .


### PR DESCRIPTION
## Summary

Phase 2.5 PR 3 of [Plan 2 (Documentation Accuracy)](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/plans/2026-05-04-documentation-accuracy.md). Adds the canonical forbidden-phrase-lint CI workflow to rcan-spec, locking in the wording-fix work from PR #204 (Phase 2) + PR #205 (Phase 2.5 PR 2).

After this PR merges, Phase 2.5 closes and Phase 3 (RRF) can begin.

### What changed

- New file: `.github/workflows/forbidden-phrase-lint.yml` (inline-form template from `RobotRegistryFoundation/robot-md`).
- Triggers on PR + push to master.
- Path filters: `README.md`, `SECURITY.md`, `CHANGELOG.md`, `VERSIONING.md`, `src/**`, `docs/**`, the workflow file itself.

### How it works

1. Workflow checks out the consumer repo (rcan-spec).
2. Sets up Python 3.12.
3. Fetches `tools/lint_forbidden_phrases.py` + `docs/standards/forbidden-phrases.json` from `craigm26/opencastor-ops` via authenticated GitHub Contents API requests using the `OPENCASTOR_OPS_READ_TOKEN` secret (fine-grained PAT, read-only Contents).
4. Runs the lint against the repo. Exits 1 (CI fails) if any forbidden phrase is found.

The `OPENCASTOR_OPS_READ_TOKEN` secret was provisioned on `continuonai/rcan-spec` immediately before this PR.

### Verification

- [x] First CI run on this PR is the live verification — if the workflow runs successfully and exits 0 (no forbidden phrases on the current main), the wiring is correct.
- [x] Path filters ensure the workflow runs on relevant file changes only.

### Sequencing

- Phase 2.5 PR 1 (closed): opencastor-ops `9ab283d` — dict allowlist update (drops 68→34 false positives).
- Phase 2.5 PR 2 (closed): rcan-spec `09bc499` (PR #205) — fixed the 34 marketing-surface hits.
- Phase 2.5 PR 3 (this): wire CI workflow + provision PAT.

After merge: Phase 3 (RRF README + RCAN integration page + API docs page + GitHub About) starts.

## Refs

- Canonical template: [RobotRegistryFoundation/robot-md/.github/workflows/forbidden-phrase-lint.yml](https://github.com/RobotRegistryFoundation/robot-md/blob/main/.github/workflows/forbidden-phrase-lint.yml)
- CI architecture decision: plan body amendment "Phase 1 verification outcome" (composite action fails cross-owner; inline form is canonical).
- Phase 2 close: `c864165` (rcan-spec PR #204)
- Phase 2.5 PR 1: opencastor-ops `9ab283d`
- Phase 2.5 PR 2: rcan-spec `09bc499` (PR #205)