### PR TITLE
fix(emit-version-tuple): pass --repo to gh release upload

### DIFF
--- a/.github/actions/emit-version-tuple/action.yml
+++ b/.github/actions/emit-version-tuple/action.yml
@@ -97,4 +97,5 @@ runs:
       run: |
         gh release upload "${{ inputs.release_tag }}" \
           "$ENV_FILE" \
-          --clobber
+          --clobber \
+          --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

Fixes the \`gh release upload\` step in the emit-version-tuple composite action so it no longer requires the calling job to have run \`actions/checkout\` first.

## The bug

\`gh\` CLI autodetects its target repo by running \`git remote\` against the working directory. In jobs without a checkout, no \`.git\` exists and \`gh\` errors:

\`\`\`
failed to run git: fatal: not a git repository (or any of the parent directories): .git
\`\`\`

This bit rcan-py's \`Publish to PyPI\` job today (run \`25291383999\`) — the package shipped to PyPI, then this action failed at the upload step, marking the workflow red. The same shape can red-flag any consumer whose release job consumes a build artifact (no checkout) instead of building from source.

## The fix

Pass \`--repo \"\${{ github.repository }}\"\` to \`gh release upload\`. In a composite-action context, \`github.repository\` evaluates to the consumer's repo (where the workflow runs) — exactly where the artifact belongs. No behavior change for consumers that already check out first.

## Test plan

- [x] Diff is one line: add \`--repo \"\${{ github.repository }}\"\` to the existing \`gh release upload\` command in action.yml.
- [ ] Empirically confirmed when the next \`rcan-py\` release tag triggers the workflow with the updated pin (separate consumer-side PR).

## Versioning

Tag as \`v3.2.3\` after merge — patch bump for a bug fix that makes the action work in checkout-less jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)