### PR TITLE
docs(about): retire OpenCastor "reference implementation" framing (Plan 9 Phase 1 F-01)

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -102,7 +102,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <p class="text-text-muted leading-relaxed mb-4">
         The reference SDKs (<a href="https://github.com/continuonai/rcan-py" class="text-accent hover:underline" target="_blank" rel="noopener">rcan-py</a>,
         <a href="https://github.com/continuonai/rcan-ts" class="text-accent hover:underline" target="_blank" rel="noopener">rcan-ts</a>)
-        and the <a href="https://opencastor.com" class="text-accent hover:underline" target="_blank" rel="noopener">OpenCastor</a> robot runtime (one reference implementation that informed the spec) are Apache 2.0 licensed. OpenCastor is not the only way to implement RCAN — it is an example.
+        and the <a href="https://opencastor.com" class="text-accent hover:underline" target="_blank" rel="noopener">OpenCastor</a> open-core RCAN runtime are Apache 2.0 licensed. OpenCastor is one of multiple ways to implement RCAN — the protocol is implementation-independent.
       </p>
       <p class="text-text-muted leading-relaxed">
         Standards engagement is underway with ISO/TC 299 WG3 (industrial robot safety) and


### PR DESCRIPTION
## Summary

Plan 9 single-finding fix: applies the one factual finding (F-01) from
[`operations/2026-05-05-apex-text-accuracy/findings-rcan-dev.md`](https://github.com/craigm26/opencastor-ops/blob/master/operations/2026-05-05-apex-text-accuracy/findings-rcan-dev.md)
in the opencastor-ops audit repo.

The Plan 9 Phase 1 audit (rcan.dev, 27 files) produced exactly one factual
finding. Two of three subagent-extracted findings were rejected as false
positives during manual verification — see the methodology section of the
findings file.

## Findings landed in this PR

- **[F-01]** `src/pages/about.astro:103-105` — Retire "OpenCastor … (one reference implementation that informed the spec) … OpenCastor is not the only way to implement RCAN — it is an example" in favour of the canonical Layer-4 description ("OpenCastor open-core RCAN runtime") and the affirmative claim that "the protocol is implementation-independent." Aligns with spec §3 Decision 2 (retire "reference implementation of RCAN" entirely) and §5 (RCAN is implementation-independent).

The forbidden-phrase regex (`reference implementation of RCAN`) does not catch the swapped/parenthesised variant on this page — this is a deliberate semantic blind-spot covered by the audit, not the lint.

## Stylistic-only findings deferred

(none — F-01a was noted as a sub-finding only and not raised, per `findings-rcan-dev.md` §F-01)

## Verification

- [x] `python3 tools/lint_forbidden_phrases.py --dict docs/standards/forbidden-phrases.json --root ~/rcan-spec` exits 0 (0 hits)
- [x] `npm run build` — 65 pages built clean, no warnings
- [x] `npx vitest run tests/functions.test.ts` — 156/156 tests pass
- [x] Manual diff review — single-line change in `src/pages/about.astro:105`

## Spec / Plan references

- North star: [`docs/superpowers/specs/2026-05-04-opencastor-ecosystem-direction-design.md`](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/specs/2026-05-04-opencastor-ecosystem-direction-design.md) §3 Decision 2 + §5
- Canonical strategy: [`business/2026-05-08-strategy-canonical.md`](https://github.com/craigm26/opencastor-ops/blob/master/business/2026-05-08-strategy-canonical.md) §3 (Layer 4 silo charter)
- Forbidden-phrase dict: [`docs/standards/forbidden-phrases.json`](https://github.com/craigm26/opencastor-ops/blob/master/docs/standards/forbidden-phrases.json) (`reference-implementation-of-rcan` regex — does not catch the variant fixed here)
- Plan 9 amendment 2026-05-05 (5-site scope): `docs/superpowers/plans/2026-05-04-apex-site-text-accuracy.md`

## Phase 2 sibling PR

This PR is the Plan 9 Phase 1 carryover. The Phase 2 sibling PR lands on
`craigm26/RobotRegistryFoundation` shortly and applies F-RRF-01..06 (six
factual findings — same F-01-pattern semantic blind-spot plus one
conformance-level number drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)