### PR TITLE
fix(compliance): bump normative-template spec version 1.6 → 3.2

### DIFF
--- a/docs/compliance/art17-qms-template.md
+++ b/docs/compliance/art17-qms-template.md
@@ -1,7 +1,7 @@
 # Article 17 — Quality Management System Template for RCAN-Based Robots
 
 **Regulation:** EU AI Act (Regulation 2024/1689), Article 17  
-**RCAN spec version:** 1.6  
+**RCAN spec version:** 3.2  
 **Document type:** QMS template  
 **Status:** Normative guidance  
 **Applies from:** 2 August 2026  

--- a/docs/compliance/art9-risk-assessment-template.md
+++ b/docs/compliance/art9-risk-assessment-template.md
@@ -2,7 +2,7 @@
 
 **Regulation:** EU AI Act (Regulation 2024/1689), Article 9  
 **Aligned standard:** ISO 12100:2010 (Safety of Machinery — Risk Assessment)  
-**RCAN spec version:** 1.6  
+**RCAN spec version:** 3.2  
 **Document type:** Risk assessment template  
 **Status:** Normative guidance  
 **Applies from:** 2 August 2026  
@@ -24,7 +24,7 @@ Article 9 requires providers of high-risk AI systems to establish, implement, do
 | Product name | [FILL] |
 | RCAN config file | [FILL: e.g., config/bob-pi4-oakd.rcan.yaml] |
 | RRN | [FILL: e.g., RRN-000000000001] |
-| RCAN version | [FILL: e.g., 1.6] |
+| RCAN version | [FILL: e.g., 3.2] |
 | AI provider | [FILL: e.g., Anthropic Claude Sonnet] |
 | Hardware platform | [FILL: e.g., Raspberry Pi 4, SO-ARM101 manipulator] |
 | Intended use | [FILL: brief description] |

--- a/docs/compliance/rcan-compliance-statement-template.md
+++ b/docs/compliance/rcan-compliance-statement-template.md
@@ -1,7 +1,7 @@
 # RCAN Protocol Compliance Statement Template
 
 **Document type:** RCAN compliance statement (per-deployment)  
-**RCAN spec version:** 1.6  
+**RCAN spec version:** 3.2  
 **Status:** Normative template  
 
 ---
@@ -26,7 +26,7 @@ RCAN PROTOCOL COMPLIANCE STATEMENT
 Robot:          [FILL: robot name]
 RRN:            [FILL: e.g., RRN-000000000001]
 Config file:    [FILL: e.g., config/arm.rcan.yaml]
-RCAN version:   [FILL: e.g., 1.6]
+RCAN version:   [FILL: e.g., 3.2]
 Runtime:        [FILL: e.g., OpenCastor v2026.3.x]
 Date:           [FILL: YYYY-MM-DD]
 Operator:       [FILL: name / organization]


### PR DESCRIPTION
## Summary

Three EU AI Act compliance templates in \`docs/compliance/\` pin **RCAN spec version 1.6** (an archived 2023-era version) in their normative header blocks AND in the \`[FILL: e.g., 1.6]\` examples operators copy into deployments:

| File | Lines changed |
|---|---|
| \`docs/compliance/rcan-compliance-statement-template.md\` | 4, 29 |
| \`docs/compliance/art9-risk-assessment-template.md\` | 5, 27 |
| \`docs/compliance/art17-qms-template.md\` | 4 |

Current spec is **3.2** per the changelog and \`opencastor-ops/config/repos.json\`.

## Why this matters

These are **normative** templates — operators are expected to fill them in verbatim as part of EU AI Act technical documentation (Art. 9 risk assessment, Art. 17 QMS, deployment compliance statement). The fill-in example \`[FILL: e.g., 1.6]\` directly instructs operators to write \"1.6\" — producing a compliance statement claiming an archived spec version. EU AI Act high-risk obligations begin 2 August 2026.

## Coordinating downstream PR

This is the **source-of-truth** mirror that \`craigm26/rcan-docs\` synchronizes from. The downstream PR landing the identical bump in the public docs site is:

→ **craigm26/rcan-docs#2**

## Build / test impact

These files live in \`docs/compliance/\` outside the Astro build path (\`src/pages/\`). No site rebuild is required, no vitest impact.

## Source

Plan 9 Phase 5 audit: \`opencastor-ops/operations/2026-05-10-findings-rcan-docs.md\` — findings **F-RCD-02**, **F-RCD-03**, **F-RCD-04**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)