### PR TITLE
fix(swarm): retire "reference implementation" framing on /use-cases/swarm/

### DIFF
--- a/src/pages/use-cases/swarm.astro
+++ b/src/pages/use-cases/swarm.astro
@@ -37,7 +37,7 @@ import CodeWindow from '../../components/CodeWindow.astro';
           Get Started Free
         </a>
         <a href="https://opencastor.com" target="_blank" rel="noopener noreferrer" class="px-8 py-4 bg-white/5 border border-white/10 text-text font-semibold text-lg rounded-full hover:bg-white/10 transition-all duration-200">
-          OpenCastor (reference impl) →
+          OpenCastor (productized runtime) →
         </a>
       </div>
     </div>
@@ -358,14 +358,14 @@ print(f"📝 Logged to chain: {record.content_hash[:16]}...")`}
     </div>
   </section>
 
-  <!-- OpenCastor Reference Implementation -->
+  <!-- OpenCastor productized runtime -->
   <section class="py-24">
     <div class="max-w-5xl mx-auto px-6">
       <div class="bg-gradient-to-br from-bg-alt/80 to-bg-alt/40 border border-cyan-500/20 rounded-3xl p-10 text-center">
         <div class="text-5xl mb-6">🦫</div>
         <h2 class="text-3xl md:text-4xl font-bold mb-4">
-          OpenCastor is the reference implementation for<br />
-          <span class="text-cyan-400">RCAN-Swarm Safe robots</span>
+          OpenCastor is the productized<br />
+          <span class="text-cyan-400">RCAN-Swarm Safe runtime</span>
         </h2>
         <p class="text-text-muted max-w-2xl mx-auto text-lg mb-8 leading-relaxed">
           OpenCastor ships with peer verification, commitment chain audit, HITL gates, confidence gates, and mDNS swarm discovery — all configured and ready to run. It is the fastest path to a RCAN-Swarm Safe robot.


### PR DESCRIPTION
## Summary

- Replace "OpenCastor is the reference implementation for RCAN-Swarm Safe robots" (H2 heading, line 367) with "OpenCastor is the productized RCAN-Swarm Safe runtime" per spec §10 line 757 canonical phrasing.
- Replace CTA button "OpenCastor (reference impl) →" (line 40) with "OpenCastor (productized runtime) →".
- Update the matching HTML comment on line 361 for consistency.

## Why

Spec §10 Decision 2 (`docs/superpowers/specs/2026-05-04-opencastor-ecosystem-direction-design.md`) retires the "reference implementation" framing for OpenCastor entirely; §3 OpenCastor anti-scope restates this:

> *"The reference implementation of RCAN-the-protocol — that label is retired (Decision 2). OpenCastor is a runtime; it's the most mature one; it's not the spec."*

Both occurrences on `/use-cases/swarm/` carried the retired framing in semantic-variant form (using "for RCAN-Swarm Safe" rather than "of RCAN"), evading the literal `forbidden-phrases.json` regex. Same blind spot as the prior Plan 9 Phase 1 audit's F-01 (`about.astro:103-105` — "one reference implementation that informed the spec") which set the precedent that retirement extends to semantic variants.

## Audit context

Caught by Plan 9 leaf sweep (2026-05-10) covering 47 .astro leaves under `src/pages/{docs,spec/v*,compliance,governance,use-cases}/`. Full findings at:

- `opencastor-ops/operations/2026-05-10-findings-rcan-dev-leaves.md` (private repo)
- Finding ID: **F-RCD-LEAF-01**

A separate deferred-issue (S-RCD-LEAF-01) for the standard certification disclaimer block missing on 5 other pages (`compliance/frameworks.astro` + `docs/{safety,training-consent,training-consent-api,mcp}.astro`) will be filed alongside.

## Test plan

- [ ] `forbidden-phrase-lint.yml` passes (this PR removes framings; cannot regress).
- [ ] `npm run build` succeeds (text-only edits inside HTML markup; no logic touched).
- [ ] Visual smoke on `/use-cases/swarm/` — hero CTA + OpenCastor promotion section render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)