### PR TITLE
chore(docs): bump JSON rcan_version examples to 3.2 across 10 docs pages

### DIFF
--- a/src/pages/docs/constrained-transport.astro
+++ b/src/pages/docs/constrained-transport.astro
@@ -227,7 +227,7 @@ RCAN_MTU_CHAR_UUID = "6e726361-6e2d-0003-0000-726361726361"  // Negotiated MTU (
 
       <pre><code>// DISCOVER response (v1.6) — payload addition
 &#123;
-  "rcan_version":        "1.6",
+  "rcan_version":        "3.2",
   "capabilities":        ["control", "safety", "training"],
   "p66_conformance_pct": 94.0,
   "supported_transports": ["http", "compact", "minimal", "ble"],

--- a/src/pages/docs/delegation.astro
+++ b/src/pages/docs/delegation.astro
@@ -21,7 +21,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
       <pre><code>&#123;
   "id":               "uuid-v4",
   "type":             1,
-  "rcan_version":     "1.5",
+  "rcan_version":     "3.2",
   "source":           "rcan://rcan.dev/org/arm/v1/unit-001",
   "target":           "rcan://rcan.dev/org/delivery/v1/unit-002",
   "delegation_chain": [

--- a/src/pages/docs/federation.astro
+++ b/src/pages/docs/federation.astro
@@ -309,7 +309,7 @@ _rcan.registry-1.acme.com. 3600 IN TXT "v=rcan1; tier=authoritative; kfp=sha256:
 
 &#123;
   "protocol":             66,
-  "rcan_version":         "1.6",
+  "rcan_version":         "3.2",
   ...
   "federation_enabled":   true,          // false = reject all cross-registry commands
   "trusted_registries":   [              // Explicit allowlist (optional; [] = trust all authoritative)

--- a/src/pages/docs/identity.astro
+++ b/src/pages/docs/identity.astro
@@ -229,7 +229,7 @@ When Alice requests a JWT:
 
 &#123;
   "protocol":             66,
-  "rcan_version":         "1.6",
+  "rcan_version":         "3.2",
   ...
   "min_loa_for_control":  2,     // Default: 1 (backward compat). Range: 1-3.
   "identity_config": &#123;

--- a/src/pages/docs/key-rotation.astro
+++ b/src/pages/docs/key-rotation.astro
@@ -83,7 +83,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
   "id":           "uuid-v4",
   "type":         27,
   "source":       "rcan://rcan.dev/org/robot/v1/unit-001",
-  "rcan_version": "1.5",
+  "rcan_version": "3.2",
   "qos":          1,
   "payload": &#123;
     "new_kid":    "rcan-key-2026-03",

--- a/src/pages/docs/messages.astro
+++ b/src/pages/docs/messages.astro
@@ -42,7 +42,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
   "ttl":             0,                  // Seconds until expiry (0 = no expiry)
   "reply_to":        null,               // ID of message being replied to
   "scope":           ["control"],        // Required RBAC scopes
-  "rcan_version":    "1.6",             // MUST be present; validated first
+  "rcan_version":    "3.2",             // MUST be present; validated first
   "qos":             1,                  // 0=fire-and-forget 1=at-least-once 2=exactly-once
   "sender_type":     "human",           // "human"|"robot"|"cloud_function"|"system"
   "key_id":          "kid-abc123"       // Optional: signing key identifier (GAP-09)
@@ -78,7 +78,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 
       <pre><code>// DISCOVER payload (v1.5)
 &#123;
-  "rcan_version": "1.5",
+  "rcan_version": "3.2",
   "capabilities": ["control", "safety", "training"],
   "p66_conformance_pct": 87.0
 &#125;</code></pre>

--- a/src/pages/docs/offline.astro
+++ b/src/pages/docs/offline.astro
@@ -30,7 +30,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 
 &#123;
   "protocol":          66,
-  "rcan_version":      "1.5",
+  "rcan_version":      "3.2",
   "offline_mode":      true,
   "offline_since_s":   1842,         // Seconds since entering offline mode
   "clock_synchronized": true,

--- a/src/pages/docs/revocation.astro
+++ b/src/pages/docs/revocation.astro
@@ -49,7 +49,7 @@ Authorization: Bearer &lt;creator-jwt&gt;
   "type":         19,
   "source":       "rcan://registry.rcan.dev",
   "target":       "rcan://*/*",          // All peers
-  "rcan_version": "1.5",
+  "rcan_version": "3.2",
   "priority":     2,
   "qos":          1,
   "payload": &#123;

--- a/src/pages/docs/safety.astro
+++ b/src/pages/docs/safety.astro
@@ -28,7 +28,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 
       <pre><code>&#123;
   "protocol": 66,
-  "rcan_version": "1.4",
+  "rcan_version": "3.2",
   "invariants": &#123;
     "local_safety_wins": true,
     "safety_messages_bypass_queues": true,
@@ -271,7 +271,7 @@ brain:
   "capabilities": ["navigation", "speech"],  // What the robot can do
   "limitations": ["cannot lift &gt; 2kg"],      // Known limitations
   "contact": "safety@example.com",           // Who to contact
-  "rcan_version": "1.4",
+  "rcan_version": "3.2",
   "p66_conformance_pct": 87,                 // Protocol 66 conformance level
   "audit_enabled": true                      // Whether actions are audited
 &#125;</code></pre>
@@ -324,7 +324,7 @@ msg = make_transparency_message(
       <p>Robots MUST expose the following new fields in <code>GET /api/safety/manifest</code>:</p>
       <pre><code>&#123;
   "protocol": 66,
-  "rcan_version": "1.5",
+  "rcan_version": "3.2",
   ...
   "clock_synchronized":  true,         // false if NTP not confirmed
   "clock_source":        "ntp",        // "ntp" | "nts" | "gps" | "manual" | "none"
@@ -359,7 +359,7 @@ X-Audit-Issuer-Sig: ed25519:...      // Ed25519 signature over root hash</code><
       <h3>JSONL Export Format</h3>
       <p>The first line is a signed header; subsequent lines are NDJSON commitment records:</p>
       <pre><code>// Line 1: header
-&#123;"type":"audit_export","from":1741000000,"to":1741086400,"count":142,"chain_root":"sha256:abc...","issuer_sig":"ed25519:xyz...","rcan_version":"1.5"&#125;
+&#123;"type":"audit_export","from":1741000000,"to":1741086400,"count":142,"chain_root":"sha256:abc...","issuer_sig":"ed25519:xyz...","rcan_version":"3.2"&#125;
 // Lines 2-N: commitment records
 &#123;"id":"...","timestamp":1741000001,"cmd":"move_forward","operator":"...","commitment_hash":"..."&#125;
 ...</code></pre>
@@ -387,7 +387,7 @@ X-Audit-Issuer-Sig: ed25519:...      // Ed25519 signature over root hash</code><
 
       <pre><code>&#123;
   "protocol":             66,
-  "rcan_version":         "1.6",
+  "rcan_version":         "3.2",
   ...
   "min_loa_for_control":  2,             // NEW v1.6 — default 1 (backward compat). See §8.7.
   "federation_enabled":   false,         // NEW v1.6 — default false. See §18.
@@ -424,7 +424,7 @@ X-Audit-Issuer-Sig: ed25519:...      // Ed25519 signature over root hash</code><
       <h3>Complete v1.6 Manifest Example</h3>
       <pre><code>&#123;
   "protocol":              66,
-  "rcan_version":          "1.6",
+  "rcan_version":          "3.2",
   "invariants": &#123;
     "local_safety_wins":               true,
     "safety_messages_bypass_queues":   true,

--- a/src/pages/docs/training-consent.astro
+++ b/src/pages/docs/training-consent.astro
@@ -74,7 +74,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
       <pre><code>&#123;
   "id":            "uuid-v4",
   "type":          10,
-  "rcan_version":  "1.5",
+  "rcan_version":  "3.2",
   "payload": &#123;
     "data_type":      "video",
     "data_hash":      "sha256:abc123",


### PR DESCRIPTION
## Summary

Bumps 16 occurrences of `"rcan_version": "X.Y"` (X.Y ∈ {1.4, 1.5, 1.6}) in JSON code examples to the current canonical `"3.2"` across 10 `src/pages/docs/*.astro` feature pages.

The `<span class="badge-new">vX.Y</span>` chips on each feature page are **intentionally preserved** — they convey "feature introduced in vX.Y" provenance, which is independent of the example payload's spec-version field value.

Closes #214.

## Files changed (16 lines / 10 files)

| File | Line(s) | Before |
|---|---|---|
| `docs/constrained-transport.astro` | 230 | `"1.6"` |
| `docs/delegation.astro` | 24 | `"1.5"` |
| `docs/federation.astro` | 312 | `"1.6"` |
| `docs/identity.astro` | 232 | `"1.6"` |
| `docs/key-rotation.astro` | 86 | `"1.5"` |
| `docs/messages.astro` | 45, 81 | `"1.6"`, `"1.5"` |
| `docs/offline.astro` | 33 | `"1.5"` |
| `docs/revocation.astro` | 52 | `"1.5"` |
| `docs/safety.astro` | 31, 274, 327, 362, 390, 427 | `"1.4"` ×2, `"1.5"` ×2, `"1.6"` ×2 |
| `docs/training-consent.astro` | 77 | `"1.5"` |

All 16 lines after this PR carry `"3.2"`.

## Why

`rcan_spec_version: 3.2` is the current canonical value per `opencastor-ops/config/repos.json`. A reader skipping the `badge-new` UI chip and looking only at the JSON example would otherwise mistake the introducing-version anchor for the current spec value.

The `forbidden-phrases.json` lint regex deliberately doesn't catch the JSON-field form (`rcan_version` with an underscore breaks the `RCAN[ -]v?...` regex; the lint targets prose patterns, not JSON examples) — which is why the systemic drift went uncaught until the Plan 9 leaf sweep called it out.

## Out of scope (deliberately preserved)

- `<span class="badge-new">vX.Y</span>` UI chips on feature pages.
- `spec/v*.astro` historical snapshots (allowlisted; reflect the spec state at that version).
- `schema_version` and other independently-versioned JSON fields.
- The 12 leaves in `spec/v*.astro` — explicitly allowlisted for all version-string rules.

## Verification

\`\`\`
$ grep -nE '"rcan_version":\s*"[12]\.' src/pages/docs/*.astro
(no matches)

$ grep -nE '"rcan_version":\s*"3\.2"' src/pages/docs/*.astro | wc -l
16

$ npm run build
[build] 65 page(s) built in 13.33s
[build] Complete!

$ npx vitest run tests/functions.test.ts
Test Files  1 passed (1)
     Tests  156 passed (156)
\`\`\`

## Audit source

- Finding ID: **S-RCD-LEAF-NOTE-01**
- Audit doc: `opencastor-ops/operations/2026-05-10-findings-rcan-dev-leaves.md` (private)
- Operator decision (2026-05-10): "Bump examples to 3.2 — one PR, ~14 files" (vs accept-as-designed or vintage-annotation).

## Companion work

- #211 — F-RCD-02/03/04 compliance template `1.6 → 3.2` bumps (same audit wave)
- #212 — F-RCD-LEAF-01 swarm.astro retired "reference implementation" framing
- #213 — S-RCD-LEAF-01 §10 cert-block on 5 regulatory pages (deferred issue)
- #214 — this PR closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)