### PR TITLE
docs(compliance): add historical-snapshot disclosure to v1.1 alignment docs

### DIFF
--- a/docs/compliance/iso-10218-alignment.md
+++ b/docs/compliance/iso-10218-alignment.md
@@ -6,7 +6,7 @@
 **Status:** Informative — historical snapshot  
 **Last updated:** 2026-03-03  
 
-> **Note:** This alignment analysis was conducted against **RCAN Spec v1.1** (archived). The current spec is **v3.2**; the protocol-layer controls referenced below remain present in current versions, but article-by-article mapping has not been re-verified against post-v1.1 changes. Treat this document as a historical reference, not a current compliance attestation.
+> **Note:** This alignment analysis was conducted at the **v1.1** epoch and is preserved as a historical record. For the latest specification state and SDK compatibility, see the live compatibility matrix at [rcan.dev/compatibility](https://rcan.dev/compatibility). The protocol-layer controls referenced below remain present in later revisions, but article-by-article mapping has not been re-verified against subsequent changes. Treat this document as a historical reference, not a current compliance attestation.
 
 ---
 

--- a/docs/compliance/iso-10218-alignment.md
+++ b/docs/compliance/iso-10218-alignment.md
@@ -3,8 +3,10 @@
 **Document type:** Compliance alignment  
 **RCAN spec version:** 1.1 (rcan.dev/spec)  
 **Standard:** ISO 10218-1:2025 — Robotics: Safety requirements for industrial robots — Part 1: Robots  
-**Status:** Informative  
+**Status:** Informative — historical snapshot  
 **Last updated:** 2026-03-03  
+
+> **Note:** This alignment analysis was conducted against **RCAN Spec v1.1** (archived). The current spec is **v3.2**; the protocol-layer controls referenced below remain present in current versions, but article-by-article mapping has not been re-verified against post-v1.1 changes. Treat this document as a historical reference, not a current compliance attestation.
 
 ---
 

--- a/docs/compliance/nist-ai-rmf-alignment.md
+++ b/docs/compliance/nist-ai-rmf-alignment.md
@@ -8,7 +8,7 @@
 **Status:** Informative — historical snapshot  
 **Last updated:** 2026-03-04  
 
-> **Note:** This alignment analysis was conducted against **RCAN Spec v1.1** (archived). The current spec is **v3.2**; the protocol-layer controls referenced below remain present in current versions, but function-by-function mapping has not been re-verified against post-v1.1 changes. Treat this document as a historical reference, not a current compliance attestation.
+> **Note:** This alignment analysis was conducted at the **v1.1** epoch and is preserved as a historical record. For the latest specification state and SDK compatibility, see the live compatibility matrix at [rcan.dev/compatibility](https://rcan.dev/compatibility). The protocol-layer controls referenced below remain present in later revisions, but function-by-function mapping has not been re-verified against subsequent changes. Treat this document as a historical reference, not a current compliance attestation.
 
 ---
 

--- a/docs/compliance/nist-ai-rmf-alignment.md
+++ b/docs/compliance/nist-ai-rmf-alignment.md
@@ -5,8 +5,10 @@
 **Framework:** NIST AI Risk Management Framework 1.0 (NIST AI 100-1, January 2023)  
 **Classification focus:** AI systems deployed in safety-critical robotics contexts; US government procurement  
 **Target audience:** Federal agencies, DoD program offices, system integrators, robot OEMs pursuing US government contracts  
-**Status:** Informative  
+**Status:** Informative — historical snapshot  
 **Last updated:** 2026-03-04  
+
+> **Note:** This alignment analysis was conducted against **RCAN Spec v1.1** (archived). The current spec is **v3.2**; the protocol-layer controls referenced below remain present in current versions, but function-by-function mapping has not been re-verified against post-v1.1 changes. Treat this document as a historical reference, not a current compliance attestation.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a historical-snapshot disclosure header to two informative compliance-alignment documents in \`docs/compliance/\` that pin **RCAN spec v1.1** in their header blocks:

- \`iso-10218-alignment.md\` (dated 2026-03-03)
- \`nist-ai-rmf-alignment.md\` (dated 2026-03-04)

Current spec is **v3.2**. Both files are \`Status: Informative\` analysis snapshots — but nothing in the body signaled that to a reader.

## Changes per file

1. Status line: \`Informative\` → \`Informative — historical snapshot\`.
2. New callout block under the header:

> **Note:** This alignment analysis was conducted against **RCAN Spec v1.1** (archived). The current spec is **v3.2**; the protocol-layer controls referenced below remain present in current versions, but article-/function-by-function mapping has not been re-verified against post-v1.1 changes. Treat this document as a historical reference, not a current compliance attestation.

The v1.1 version label itself is **preserved** as intentional historical provenance.

## Downstream mirror

Same edit lands at \`craigm26/rcan-docs/docs/compliance/\` in **craigm26/rcan-docs#8**. These rcan-spec files are the source-of-truth that rcan-docs mirrors.

## Build / test impact

Files live in \`docs/compliance/\` outside the Astro build path (\`src/pages/\`). No site rebuild required, no vitest impact.

## Source

Plan 9 Phase 5 audit: \`opencastor-ops/operations/2026-05-10-findings-rcan-docs.md\` — finding **S-RCD-01**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)