### PR TITLE
docs(verification): drop stale "in RCAN protocol v2" tail

### DIFF
--- a/docs/verification/manufacturer-verification.md
+++ b/docs/verification/manufacturer-verification.md
@@ -83,7 +83,7 @@ Community verification confirms the identity data is plausible and community-rev
 }
 ```
 
-> **Note on `signature`:** The `"pending"` value is a placeholder for the initial submission phase. A future version of the protocol will require a cryptographic signature (e.g., Ed25519) over the canonical JSON payload. Manufacturers should structure their tooling to accommodate this field being populated with a real signature in RCAN protocol v2.
+> **Note on `signature`:** The `"pending"` value is a placeholder for the initial submission phase. A future version of the protocol will require a cryptographic signature (e.g., Ed25519) over the canonical JSON payload. Manufacturers should structure their tooling to accommodate this field being populated with a real signature.
 
 **RURI Endpoint Validation:**
 


### PR DESCRIPTION
## Summary

Mirrors **craigm26/rcan-docs#10**. \`docs/verification/manufacturer-verification.md\` line 86 trailed the future-signature note with *"...in RCAN protocol v2."* The v2 series (v2.0–v2.3) is now archived; current spec is **v3.2**.

The paragraph already opens with *"A future version of the protocol will require..."* — the trailing *"in RCAN protocol v2"* is both redundant and stale. This PR drops it.

## Diff

\`\`\`diff
- ...to accommodate this field being populated with a real signature in RCAN protocol v2.
+ ...to accommodate this field being populated with a real signature.
\`\`\`

## Build / test impact

File lives in \`docs/verification/\` outside the Astro build path (\`src/pages/\`). No site rebuild required, no vitest impact.

## Source

Plan 9 Phase 5 audit: \`opencastor-ops/operations/2026-05-10-findings-rcan-docs.md\` — finding **S-RCD-03**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)