### PR TITLE
chore: move rcan-spec to RobotRegistryFoundation (org migration + governance)

### DIFF
--- a/.github/actions/emit-version-tuple/README.md
+++ b/.github/actions/emit-version-tuple/README.md
@@ -5,7 +5,7 @@ Composite action that builds a version-tuple payload, hybrid-signs it (ML-DSA-65
 ## Usage (hybrid — recommended)
 
 ```yaml
-- uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.0
+- uses: RobotRegistryFoundation/rcan-spec/.github/actions/emit-version-tuple@v3.2.0
   with:
     project: robot-md
     ran: ${{ secrets.ROBOT_MD_RAN }}

--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -57,7 +57,7 @@ jobs:
           SPEC_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           gh issue create \
-            --repo continuonai/rcan-py \
+            --repo RobotRegistryFoundation/rcan-py \
             --title "chore: update SDK for RCAN spec ${SPEC_TAG}" \
             --body "RCAN spec ${SPEC_TAG} released. Update SPEC_VERSION in rcan/validate.py, run tests, bump version if needed, publish to PyPI. See https://rcan.dev/changelog/" \
           || echo "Issue may already exist or PAT not configured, continuing"
@@ -69,7 +69,7 @@ jobs:
           SPEC_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           gh issue create \
-            --repo continuonai/rcan-ts \
+            --repo RobotRegistryFoundation/rcan-ts \
             --title "chore: update SDK for RCAN spec ${SPEC_TAG}" \
             --body "RCAN spec ${SPEC_TAG} released. Update SPEC_VERSION constant, run npm test and build, bump version if needed, publish to npm. See https://rcan.dev/changelog/" \
           || echo "Issue may already exist or PAT not configured, continuing"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 The official specification for the RCAN (Robot Communication and Autonomy Network) protocol. Published at **rcan.dev** via Cloudflare Pages. Astro-based static site.
 
-**Current version**: v3.2 | **Repo**: continuonai/rcan-spec | **Branch**: master
+**Current version**: v3.2 | **Repo**: RobotRegistryFoundation/rcan-spec | **Branch**: master
 
 Version format: `vMAJOR.MINOR.PATCH` — this is the primary compliance reference for all ecosystem repos.
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# RCAN specification — stewarded by the Robot Registry Foundation.
+# Default owner for review. Replace with an @RobotRegistryFoundation/<team>
+# once a maintainers team exists.
+* @craigm26

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to RCAN
+
+RCAN is an open standard stewarded by the
+[Robot Registry Foundation](https://github.com/RobotRegistryFoundation).
+
+- **Normative spec changes** go through the public process described in
+  [`docs/governance/robot-registry-foundation.md`](docs/governance/robot-registry-foundation.md):
+  open an issue (label `spec-change` for normative changes, `discussion` for
+  exploratory ideas), allow the public comment period, then PR.
+- **SDKs** live in
+  [`rcan-py`](https://github.com/RobotRegistryFoundation/rcan-py) (Python) and
+  [`rcan-ts`](https://github.com/RobotRegistryFoundation/rcan-ts) (TypeScript).
+- **Security issues:** see [`SECURITY.md`](SECURITY.md).
+
+Issues and PRs are welcome here.

--- a/README.md
+++ b/README.md
@@ -139,3 +139,7 @@ Current versions for all packages: see the [live compatibility matrix](https://r
 
 Specification text: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 Reference implementations: MIT.
+
+---
+
+> **Stewarded by the [Robot Registry Foundation](https://github.com/RobotRegistryFoundation).** RCAN is an open standard; issues, proposals, and PRs are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Spec](https://img.shields.io/badge/spec-live%20matrix-blue)](https://rcan.dev/compatibility)
 [![License](https://img.shields.io/badge/license-CC%20BY%204.0-green)](https://creativecommons.org/licenses/by/4.0/)
-[![CI](https://github.com/continuonai/rcan-spec/actions/workflows/ci.yml/badge.svg)](https://github.com/continuonai/rcan-spec/actions)
+[![CI](https://github.com/RobotRegistryFoundation/rcan-spec/actions/workflows/ci.yml/badge.svg)](https://github.com/RobotRegistryFoundation/rcan-spec/actions)
 
 **[→ Read the spec at rcan.dev/spec/](https://rcan.dev/spec/) · [→ Live compatibility matrix](https://rcan.dev/compatibility)**
 
@@ -23,8 +23,8 @@ This repo is the **wire-protocol specification** of a small, composable, Apache/
 | **Declaration** | [ROBOT.md](https://github.com/RobotRegistryFoundation/robot-md) | The file a robot ships at its root. YAML frontmatter + markdown prose. Declares identity, capabilities, safety gates. Spec + Python CLI. |
 | **Agent bridge** | [robot-md-mcp](https://github.com/RobotRegistryFoundation/robot-md-mcp) | MCP server that exposes a `ROBOT.md` to Claude Code, Claude Desktop, Cursor, Zed, Gemini CLI — any MCP-aware agent. One `claude mcp add` away. |
 | **Wire protocol** ← *this* | [RCAN](https://rcan.dev/spec/) | How robots, gateways, and planners talk. Signed envelopes, LoA enforcement, PQC crypto, EU AI Act §23–§27 compliance blocks. |
-| **Python SDK** | [rcan-py](https://github.com/continuonai/rcan-py) | `pip install rcan` — RCANMessage, RobotURI, ConfidenceGate, HiTLGate, AuditChain. |
-| **TypeScript SDK** | [rcan-ts](https://github.com/continuonai/rcan-ts) | `npm install rcan-ts` — same API surface for Node + browser. |
+| **Python SDK** | [rcan-py](https://github.com/RobotRegistryFoundation/rcan-py) | `pip install rcan` — RCANMessage, RobotURI, ConfidenceGate, HiTLGate, AuditChain. |
+| **TypeScript SDK** | [rcan-ts](https://github.com/RobotRegistryFoundation/rcan-ts) | `npm install rcan-ts` — same API surface for Node + browser. |
 | **Registry** | [Robot Registry Foundation](https://robotregistryfoundation.org) | Permanent RRN identities. Public resolver at `/r/<rrn>`. Like ICANN for robots. |
 | **Productized runtime (Layer 4)** | [OpenCastor](https://github.com/craigm26/OpenCastor) | Open-source productized RCAN runtime — connects LLM brains to hardware bodies. One implementation of RCAN. |
 
@@ -75,8 +75,8 @@ Robots today are islands. A Boston Dynamics Spot and a Raspberry Pi rover can't 
 
 | SDK | Language | Install | Tests |
 |---|---|---|---|
-| [rcan-py](https://github.com/continuonai/rcan-py) | Python 3.10+ | `pip install rcan` | 754 |
-| [rcan-ts](https://github.com/continuonai/rcan-ts) | TypeScript / Node 18+ | `npm install rcan-ts` | 447 |
+| [rcan-py](https://github.com/RobotRegistryFoundation/rcan-py) | Python 3.10+ | `pip install rcan` | 754 |
+| [rcan-ts](https://github.com/RobotRegistryFoundation/rcan-ts) | TypeScript / Node 18+ | `npm install rcan-ts` | 447 |
 | [OpenCastor](https://github.com/craigm26/OpenCastor) | Python (robot runtime) | `pip install opencastor` | 6,459 |
 
 ## Companion formats
@@ -119,15 +119,15 @@ npm run build    # production → dist/
 npm run test     # conformance tests
 ```
 
-Open issues and proposals at [github.com/continuonai/rcan-spec/issues](https://github.com/continuonai/rcan-spec/issues). Major changes go through a public comment period before merging.
+Open issues and proposals at [github.com/RobotRegistryFoundation/rcan-spec/issues](https://github.com/RobotRegistryFoundation/rcan-spec/issues). Major changes go through a public comment period before merging.
 
 ## Ecosystem
 
 | Package | Purpose |
 |---|---|
 | **rcan-spec** (this) | Protocol specification |
-| [rcan-py](https://github.com/continuonai/rcan-py) | Python SDK |
-| [rcan-ts](https://github.com/continuonai/rcan-ts) | TypeScript SDK |
+| [rcan-py](https://github.com/RobotRegistryFoundation/rcan-py) | Python SDK |
+| [rcan-ts](https://github.com/RobotRegistryFoundation/rcan-ts) | TypeScript SDK |
 | [OpenCastor](https://github.com/craigm26/OpenCastor) | Productized robot runtime (Layer 4) |
 | [RRF](https://robotregistryfoundation.org) | Robot identity registry |
 | [Fleet UI](https://app.opencastor.com) | Web fleet dashboard |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ Security fixes are backported to the current stable version and the previous min
 
 Report privately via one of the following:
 
-- **GitHub Security Advisories** (preferred): [github.com/continuonai/rcan-spec/security/advisories/new](https://github.com/continuonai/rcan-spec/security/advisories/new)
+- **GitHub Security Advisories** (preferred): [github.com/RobotRegistryFoundation/rcan-spec/security/advisories/new](https://github.com/RobotRegistryFoundation/rcan-spec/security/advisories/new)
 - **Email**: security@continuon.ai — encrypt with PGP if the report contains sensitive detail (public key at rcan.dev/security.asc)
 
 Include in your report:

--- a/docs/governance/robot-registry-foundation.md
+++ b/docs/governance/robot-registry-foundation.md
@@ -2,7 +2,7 @@
 
 > **Status: DRAFT** · Last revised: 2026-03-04
 > Seeking co-founders, endorsing organizations, and stakeholder input.
-> → Discuss on [GitHub issue #13](https://github.com/continuonai/rcan-spec/issues/13)
+> → Discuss on [GitHub issue #13](https://github.com/RobotRegistryFoundation/rcan-spec/issues/13)
 
 ---
 
@@ -137,7 +137,7 @@ The Robot Registry Foundation governs the following areas:
 The RRF maintains the authoritative namespace of **Robot Registration Numbers (RRNs)**. It delegates namespace prefixes to Authoritative nodes (manufacturers, enterprises) and reserves the root namespace for robots without a dedicated organisational registry.
 
 ### 2. RCAN Specification Stewardship
-The RRF stewards the RCAN protocol specification hosted at [github.com/continuonai/rcan-spec](https://github.com/continuonai/rcan-spec). This includes:
+The RRF stewards the RCAN protocol specification hosted at [github.com/RobotRegistryFoundation/rcan-spec](https://github.com/RobotRegistryFoundation/rcan-spec). This includes:
 - Accepting and reviewing proposed specification changes via GitHub issues and pull requests.
 - Maintaining the canonical spec version and changelog.
 - Publishing normative conformance requirements for each spec version.
@@ -172,7 +172,7 @@ RCAN is developed in the open. Anyone may propose changes to the specification, 
 
 ### Proposing a Spec Change
 
-1. **Open a GitHub issue** at [continuonai/rcan-spec](https://github.com/continuonai/rcan-spec/issues) describing the problem or proposal. Use the `spec-change` label for normative changes, `discussion` for exploratory ideas.
+1. **Open a GitHub issue** at [RobotRegistryFoundation/rcan-spec](https://github.com/RobotRegistryFoundation/rcan-spec/issues) describing the problem or proposal. Use the `spec-change` label for normative changes, `discussion` for exploratory ideas.
 2. **Gather feedback** — a minimum 14-day open comment period applies to all normative changes. Breaking changes require 30 days.
 3. **Open a pull request** with the proposed change. PRs must include: updated spec text, rationale, backward-compatibility analysis, and (for new message types) a wire format definition.
 4. **Review** — the chair or a delegated reviewer approves or requests changes. Two approvals are required for normative changes.
@@ -305,11 +305,11 @@ No commitments have been made. This charter is an invitation to collaborate.
 
 | Role | What to do |
 |------|-----------|
-| **Co-founder** | Comment on [GitHub issue #13](https://github.com/continuonai/rcan-spec/issues/13) expressing intent to co-found; include your organization name and primary interest |
+| **Co-founder** | Comment on [GitHub issue #13](https://github.com/RobotRegistryFoundation/rcan-spec/issues/13) expressing intent to co-found; include your organization name and primary interest |
 | **Endorsing organization** | Post a short statement of endorsement on issue #13; no financial commitment required at this stage |
 | **Technical contributor** | Open a pull request against `docs/governance/` with proposed amendments |
 | **Standards body representative** | Contact the RCAN maintainers directly via the repository to discuss formal liaison |
-| **Interested observer** | ⭐ Star the [rcan-spec repository](https://github.com/continuonai/rcan-spec) and subscribe to issue #13 for updates |
+| **Interested observer** | ⭐ Star the [rcan-spec repository](https://github.com/RobotRegistryFoundation/rcan-spec) and subscribe to issue #13 for updates |
 
 We are particularly seeking input from:
 - Robot manufacturers (large and small) currently implementing RCAN.

--- a/docs/superpowers/plans/2026-06-03-rcan-foundation-migration.md
+++ b/docs/superpowers/plans/2026-06-03-rcan-foundation-migration.md
@@ -1,0 +1,406 @@
+# RCAN → Robot Registry Foundation migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the RCAN trio (`rcan-spec`, `rcan-py`, `rcan-ts`) from the `continuonai` org to `RobotRegistryFoundation`, re-point every CI reference across 8 repos, register OIDC trusted publishers under the new owner, and verify — with published package names unchanged.
+
+**Architecture:** GitHub repo transfer (preserves history/issues/tags/releases/secrets, creates redirects) followed by an ecosystem-wide CI-ref sweep. The risk surface is one class of dependency only — the shared GitHub Actions hosted in the trio (`emit-version-tuple` in rcan-spec, `validate-rcan` in rcan-py); code imports of the published `rcan`/`rcan-ts` packages are unaffected. Redirects cover the migration window; the end state must contain zero `continuonai/rcan` references in tracked CI/metadata files.
+
+**Tech Stack:** GitHub (repo transfer API + Actions), `gh` CLI, git, PyPI + npm OIDC Trusted Publishing.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-rcan-foundation-migration-design.md`
+
+**Legend:** `[OPERATOR]` = a human-only action (web UI / privileged API). `[AGENT]` = scriptable by the executing agent. Pushing/PR-merging is operator-gated.
+
+---
+
+## Repo & ref inventory (the complete edit set)
+
+| Repo | Remote (current) | Role | Refs to fix |
+|------|------------------|------|-------------|
+| rcan-spec | continuonai/rcan-spec | transfer + edit | `release-notify.yml` (`--repo continuonai/rcan-py`, `--repo continuonai/rcan-ts`); `.github/actions/emit-version-tuple/README.md` (usage example) |
+| rcan-py | continuonai/rcan-py | transfer + edit | `publish.yml` (`--repo continuonai/rcan-py` ×4, `uses: …rcan-spec…` ×2); `pyproject.toml` Repository; `docs/ci-integration.md` (validate-rcan refs) |
+| rcan-ts | continuonai/rcan-ts | transfer + edit | `publish.yml` (`uses: …rcan-spec…` ×2, OIDC comment "org continuonai"); `package.json` repository/bugs/homepage; `src/index.ts` @see |
+| OpenCastor | craigm26/OpenCastor | edit only | `release.yml` (`uses: …rcan-spec…` ×2) |
+| robot-md | RobotRegistryFoundation/robot-md | edit only | `release.yml` ×2 |
+| robot-md-gateway | RobotRegistryFoundation/robot-md-gateway | edit only | `release.yml` ×2 |
+| robot-md-mcp | RobotRegistryFoundation/robot-md-mcp | edit only | `release.yml` ×2 |
+| RobotRegistryFoundation | craigm26/RobotRegistryFoundation | edit only | `release.yml` ×1 |
+
+**Canonical substitution (apply only to listed files, never CHANGELOG):**
+```
+continuonai/rcan-spec → RobotRegistryFoundation/rcan-spec
+continuonai/rcan-py   → RobotRegistryFoundation/rcan-py
+continuonai/rcan-ts   → RobotRegistryFoundation/rcan-ts
+```
+
+**Must NOT change:** `rcan://…/continuonai/…` example URIs (manufacturer namespace); historical `@continuonai/rcan-ts` CHANGELOG entries.
+
+---
+
+## Phase 0 — Pre-flight (no repository changes)
+
+### Task 0.1: [OPERATOR] Confirm rights + snapshot secrets/environment
+
+- [ ] **Step 1: Confirm transfer rights**
+Verify you are an owner/admin of `continuonai` (source) and can create repos in `RobotRegistryFoundation` (target). Both appear in `gh api /user/orgs --jq '.[].login'`.
+
+- [ ] **Step 2: Snapshot trio secrets + environment (the "before")**
+
+Run:
+```bash
+for r in rcan-spec rcan-py rcan-ts; do
+  echo "== $r secrets =="; gh secret list --repo continuonai/$r
+  echo "== $r environments =="; gh api repos/continuonai/$r/environments --jq '.environments[].name' 2>/dev/null
+done
+```
+Expected: lists include `RCAN_PY_RELEASE_*` / `RCAN_TS_RELEASE_*` (+ `PYPI_TOKEN`/`NPM_TOKEN`) and rcan-py shows a `pypi` environment. **Save this output** — it is the checklist for Phase 3 verification.
+
+### Task 0.2: [OPERATOR] Freeze releases
+
+- [ ] **Step 1:** Announce a release freeze across all 8 repos for the migration window — no `v*` tag pushes and no `Release`/`publish_npm` workflow dispatches until Phase 5 unfreeze. (No command; coordination only. If a release is mid-pipeline, wait for it to finish before Phase 1.)
+
+### Task 0.3: [AGENT] Record the baseline ref inventory
+
+- [ ] **Step 1: Capture current refs as the known "before"**
+
+Run (from `~`):
+```bash
+for r in rcan-spec rcan-py rcan-ts OpenCastor robot-md robot-md-gateway robot-md-mcp RobotRegistryFoundation; do
+  echo "## $r"; git -C $r grep -nI 'continuonai/rcan' -- '.github/**' 'pyproject.toml' 'package.json' 'src/index.ts' 'docs/ci-integration.md' 2>/dev/null
+done | tee /tmp/rcan-migration-before.txt
+```
+Expected: non-empty matches in every repo (matches the inventory table above).
+
+- [ ] **Step 2: Commit nothing** — this is a read-only baseline; the file lives in `/tmp`.
+
+---
+
+## Phase 1 — Transfer the 3 repos
+
+### Task 1.1: [OPERATOR] Transfer rcan-spec, rcan-py, rcan-ts
+
+- [ ] **Step 1: Transfer each repo to RobotRegistryFoundation**
+
+Run (web UI alternative: each repo → Settings → "Transfer ownership"):
+```bash
+for r in rcan-spec rcan-py rcan-ts; do
+  gh api --method POST repos/continuonai/$r/transfer -f new_owner=RobotRegistryFoundation
+done
+```
+Expected: HTTP 202 each. (Org-to-org transfer may require accepting in the target org UI.)
+
+- [ ] **Step 2: Verify each landed with history/tags/releases/secrets**
+
+Run:
+```bash
+for r in rcan-spec rcan-py rcan-ts; do
+  echo "== $r =="
+  gh repo view RobotRegistryFoundation/$r --json name,isPrivate --jq '.name'
+  gh release list --repo RobotRegistryFoundation/$r | head -3
+  gh secret list --repo RobotRegistryFoundation/$r
+done
+```
+Expected: repo resolves under the new owner; releases present; secrets list matches the Phase 0 snapshot. **Note any missing secret** for Phase 3.
+
+### Task 1.2: [AGENT] Re-point local remotes
+
+- [ ] **Step 1: Update each local clone's origin**
+
+Run:
+```bash
+for r in rcan-spec rcan-py rcan-ts; do
+  git -C ~/$r remote set-url origin https://github.com/RobotRegistryFoundation/$r.git
+  echo "$r -> $(git -C ~/$r remote get-url origin)"
+done
+```
+Expected: all three print `…RobotRegistryFoundation/…`.
+
+- [ ] **Step 2: Verify fetch works through the new remote**
+
+Run: `git -C ~/rcan-spec ls-remote --heads origin >/dev/null && echo OK`
+Expected: `OK`.
+
+---
+
+## Phase 2 — Re-point the CI hub (load-bearing)
+
+> For each repo: create a branch, apply the file-scoped substitution, verify **zero** `continuonai/rcan` refs remain in the touched files, commit. Pushing/PR is operator-gated (Step "push").
+
+### Task 2.1: [AGENT] rcan-spec CI refs
+
+**Files:** Modify `~/rcan-spec/.github/workflows/release-notify.yml`, `~/rcan-spec/.github/actions/emit-version-tuple/README.md`
+
+- [ ] **Step 1: Branch**
+```bash
+cd ~/rcan-spec && git checkout -b chore/rrf-org-ci-refs master
+```
+
+- [ ] **Step 2: Apply substitution to the two files only**
+```bash
+sed -i 's#continuonai/rcan-py#RobotRegistryFoundation/rcan-py#g; s#continuonai/rcan-ts#RobotRegistryFoundation/rcan-ts#g; s#continuonai/rcan-spec#RobotRegistryFoundation/rcan-spec#g' \
+  .github/workflows/release-notify.yml .github/actions/emit-version-tuple/README.md
+```
+
+- [ ] **Step 3: Verify zero refs remain + YAML still parses**
+```bash
+git grep -nI 'continuonai/rcan' -- .github/workflows/release-notify.yml .github/actions/emit-version-tuple/README.md || echo "CLEAN"
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release-notify.yml')); print('YAML OK')"
+```
+Expected: `CLEAN` then `YAML OK`.
+
+- [ ] **Step 4: Commit**
+```bash
+git add .github/workflows/release-notify.yml .github/actions/emit-version-tuple/README.md
+git commit -m "chore(ci): point release-notify + action docs at RobotRegistryFoundation"
+```
+
+- [ ] **Step 5: [OPERATOR] Push + PR** `gh pr create --fill --base master` (after operator go-ahead).
+
+### Task 2.2: [AGENT] rcan-py CI refs
+
+**Files:** Modify `~/rcan-py/.github/workflows/publish.yml`
+
+- [ ] **Step 1: Branch** `cd ~/rcan-py && git checkout -b chore/rrf-org-ci-refs main`
+
+- [ ] **Step 2: Apply substitution (workflow only)**
+```bash
+sed -i 's#continuonai/rcan-py#RobotRegistryFoundation/rcan-py#g; s#continuonai/rcan-spec#RobotRegistryFoundation/rcan-spec#g' \
+  .github/workflows/publish.yml
+```
+This fixes the four `--repo continuonai/rcan-py` lines and the two `uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3` lines.
+
+- [ ] **Step 3: Verify + parse**
+```bash
+git grep -nI 'continuonai/rcan' -- .github/workflows/publish.yml || echo "CLEAN"
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml')); print('YAML OK')"
+```
+Expected: `CLEAN` then `YAML OK`.
+
+- [ ] **Step 4: Commit**
+```bash
+git add .github/workflows/publish.yml
+git commit -m "chore(ci): point publish workflow at RobotRegistryFoundation"
+```
+
+- [ ] **Step 5: [OPERATOR] Push + PR** (`--base main`, after go-ahead).
+
+### Task 2.3: [AGENT] rcan-ts CI refs
+
+**Files:** Modify `~/rcan-ts/.github/workflows/publish.yml`
+
+- [ ] **Step 1: Branch** `cd ~/rcan-ts && git checkout -b chore/rrf-org-ci-refs master`
+
+- [ ] **Step 2: Apply substitution + fix the OIDC comment**
+```bash
+sed -i 's#continuonai/rcan-spec#RobotRegistryFoundation/rcan-spec#g; s#org continuonai, repo rcan-ts#org RobotRegistryFoundation, repo rcan-ts#g' \
+  .github/workflows/publish.yml
+```
+
+- [ ] **Step 3: Verify + parse**
+```bash
+git grep -nI 'continuonai' -- .github/workflows/publish.yml || echo "CLEAN"
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml')); print('YAML OK')"
+```
+Expected: `CLEAN` then `YAML OK`.
+
+- [ ] **Step 4: Commit**
+```bash
+git add .github/workflows/publish.yml
+git commit -m "chore(ci): point publish workflow + OIDC note at RobotRegistryFoundation"
+```
+
+- [ ] **Step 5: [OPERATOR] Push + PR** (`--base master`, after go-ahead).
+
+### Task 2.4: [AGENT] Sweep the 5 consumer repos
+
+**Files:** Modify the `release.yml` in each of: OpenCastor, robot-md, robot-md-gateway, robot-md-mcp, RobotRegistryFoundation.
+
+Each consumer references only `uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3`; the substitution is identical.
+
+- [ ] **Step 1: For each repo — branch, substitute, verify, commit**
+```bash
+for r in OpenCastor robot-md robot-md-gateway robot-md-mcp RobotRegistryFoundation; do
+  cd ~/$r || continue
+  base=$(git symbolic-ref --short HEAD)               # current default checkout
+  git checkout -b chore/rrf-org-ci-refs
+  sed -i 's#continuonai/rcan-spec#RobotRegistryFoundation/rcan-spec#g' .github/workflows/release.yml
+  echo "== $r =="
+  git grep -nI 'continuonai/rcan-spec' -- .github/workflows/release.yml || echo "  CLEAN"
+  python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('  YAML OK')"
+  git add .github/workflows/release.yml
+  git commit -m "chore(ci): point rcan-spec action ref at RobotRegistryFoundation"
+done
+```
+Expected: each repo prints `CLEAN` then `YAML OK`, then commits.
+
+- [ ] **Step 2: Confirm all 5 branches committed**
+```bash
+for r in OpenCastor robot-md robot-md-gateway robot-md-mcp RobotRegistryFoundation; do
+  echo "$r: $(git -C ~/$r log --oneline -1)"
+done
+```
+Expected: each shows the new `chore(ci): point rcan-spec action ref…` commit.
+
+- [ ] **Step 3: [OPERATOR] Push + PR each** (after go-ahead):
+```bash
+for r in OpenCastor robot-md robot-md-gateway robot-md-mcp RobotRegistryFoundation; do
+  git -C ~/$r push -u origin chore/rrf-org-ci-refs && gh pr create --repo $(git -C ~/$r remote get-url origin | sed -E 's#.*github.com[:/](.+)\.git#\1#') --fill --head chore/rrf-org-ci-refs
+done
+```
+
+---
+
+## Phase 3 — Publishing trust under the new owner
+
+### Task 3.1: [OPERATOR] Register PyPI trusted publisher
+
+- [ ] **Step 1:** Log into PyPI **from the account that owns `rcan`** (resolve the cmmerry@ucdavis vs craigm26@gmail ambiguity first — open Your Projects and confirm `rcan` is manageable).
+- [ ] **Step 2:** `rcan` → Manage → Publishing → GitHub Actions → Add:
+  - Owner: `RobotRegistryFoundation`
+  - Repository: `rcan-py`
+  - Workflow filename: `publish.yml`
+  - Environment: `pypi`
+- [ ] **Step 3: Verify** a "trusted publisher" row now lists `RobotRegistryFoundation/rcan-py @ publish.yml (pypi)`.
+
+### Task 3.2: [OPERATOR] Register npm trusted publisher
+
+- [ ] **Step 1:** npmjs.com → `rcan-ts` package → Settings → Trusted Publisher → GitHub Actions:
+  - Organization or user: `RobotRegistryFoundation`
+  - Repository: `rcan-ts`
+  - Workflow filename: `publish.yml`
+  - Environment: **leave blank** (npm-publish job sets no `environment:`)
+- [ ] **Step 2: Verify** the package's Trusted Publisher shows `RobotRegistryFoundation/rcan-ts @ publish.yml`.
+
+### Task 3.3: [OPERATOR] Verify release-signing secrets + environment survived transfer
+
+- [ ] **Step 1: Compare against the Phase 0 snapshot**
+```bash
+gh secret list --repo RobotRegistryFoundation/rcan-py
+gh secret list --repo RobotRegistryFoundation/rcan-ts
+gh api repos/RobotRegistryFoundation/rcan-py/environments --jq '.environments[].name'
+```
+Expected: `RCAN_PY_RELEASE_*` / `RCAN_TS_RELEASE_*` present; `pypi` environment present.
+- [ ] **Step 2:** Re-create any secret/environment that did not transfer (env secrets are not documented as transferred). Use the operator's key custody for `RCAN_*_RELEASE_*` values.
+
+---
+
+## Phase 4 — Metadata + governance polish
+
+### Task 4.1: [AGENT] rcan-py metadata + docs
+
+**Files:** Modify `~/rcan-py/pyproject.toml`, `README.md`, `SECURITY.md` (if present), `CLAUDE.md`, `docs/ci-integration.md`. (Continue on branch `chore/rrf-org-ci-refs` or a `docs/rrf-org-metadata` branch.)
+
+- [ ] **Step 1: Substitute owner in metadata/docs (NOT CHANGELOG)**
+```bash
+cd ~/rcan-py
+for f in pyproject.toml README.md CLAUDE.md docs/ci-integration.md; do
+  [ -f "$f" ] && sed -i 's#continuonai/rcan-py#RobotRegistryFoundation/rcan-py#g; s#continuonai/rcan-spec#RobotRegistryFoundation/rcan-spec#g; s#continuonai/rcan-ts#RobotRegistryFoundation/rcan-ts#g' "$f"
+done
+```
+- [ ] **Step 2: Verify**
+```bash
+git grep -nI 'continuonai/rcan' -- pyproject.toml README.md CLAUDE.md docs/ci-integration.md || echo "CLEAN"
+grep -n 'Repository' pyproject.toml
+```
+Expected: `CLEAN`; Repository now `https://github.com/RobotRegistryFoundation/rcan-py`.
+- [ ] **Step 3: Commit** `git commit -am "docs: point rcan-py metadata + docs at RobotRegistryFoundation"`
+
+### Task 4.2: [AGENT] rcan-ts metadata + docs
+
+**Files:** Modify `~/rcan-ts/package.json`, `src/index.ts`, `README.md`, `CLAUDE.md`.
+
+- [ ] **Step 1: Substitute (NOT CHANGELOG)**
+```bash
+cd ~/rcan-ts
+for f in package.json src/index.ts README.md CLAUDE.md; do
+  [ -f "$f" ] && sed -i 's#continuonai/rcan-ts#RobotRegistryFoundation/rcan-ts#g; s#continuonai/rcan-py#RobotRegistryFoundation/rcan-py#g; s#continuonai/rcan-spec#RobotRegistryFoundation/rcan-spec#g' "$f"
+done
+```
+- [ ] **Step 2: Verify package.json still parses + refs clean**
+```bash
+node -e "require('./package.json'); console.log('package.json OK')"
+git grep -nI 'continuonai/rcan' -- package.json src/index.ts README.md CLAUDE.md || echo "CLEAN"
+```
+Expected: `package.json OK` then `CLEAN`. (CLAUDE.md line "NOT `@continuonai/rcan`, which 404s" is historical context — acceptable to leave; if changed, ensure it still reads sensibly.)
+- [ ] **Step 3: Commit** `git commit -am "docs: point rcan-ts metadata + docs at RobotRegistryFoundation"`
+
+### Task 4.3: [AGENT] rcan-spec docs
+
+**Files:** Modify `~/rcan-spec/README.md`, `SECURITY.md`, `CLAUDE.md`, `docs/governance/robot-registry-foundation.md`.
+
+- [ ] **Step 1: Substitute (NOT CHANGELOG; leave whitepaper/compliance historical docs unless desired)**
+```bash
+cd ~/rcan-spec
+for f in README.md SECURITY.md CLAUDE.md docs/governance/robot-registry-foundation.md; do
+  [ -f "$f" ] && sed -i 's#continuonai/rcan-spec#RobotRegistryFoundation/rcan-spec#g; s#continuonai/rcan-py#RobotRegistryFoundation/rcan-py#g; s#continuonai/rcan-ts#RobotRegistryFoundation/rcan-ts#g' "$f"
+done
+```
+- [ ] **Step 2: Verify**
+```bash
+git grep -nI 'continuonai/rcan' -- README.md SECURITY.md CLAUDE.md docs/governance/robot-registry-foundation.md || echo "CLEAN"
+```
+Expected: `CLEAN`. (Governance doc line 140 now reads "hosted at github.com/RobotRegistryFoundation/rcan-spec".)
+- [ ] **Step 3: Commit** `git commit -am "docs: point rcan-spec metadata + governance at RobotRegistryFoundation"`
+
+### Task 4.4: [AGENT] Governance polish (CODEOWNERS + CONTRIBUTING pointer + stewardship note)
+
+**Files:** Create `CODEOWNERS` + add a stewardship line to `README.md` in each of rcan-spec, rcan-py, rcan-ts; ensure a `CONTRIBUTING.md` pointer exists.
+
+- [ ] **Step 1: Add CODEOWNERS + stewardship note per repo**
+```bash
+for r in rcan-spec rcan-py rcan-ts; do
+  cd ~/$r
+  printf '* @RobotRegistryFoundation/maintainers\n' > CODEOWNERS
+  # Stewardship note appended after the first heading block if not already present:
+  grep -q 'Stewarded by the Robot Registry Foundation' README.md || \
+    printf '\n> Stewarded by the [Robot Registry Foundation](https://github.com/RobotRegistryFoundation). RCAN is an open standard; contributions welcome.\n' >> README.md
+  [ -f CONTRIBUTING.md ] || printf '# Contributing\n\nRCAN is stewarded by the Robot Registry Foundation. Open issues and PRs here; normative spec changes go through the process in `rcan-spec`.\n' > CONTRIBUTING.md
+done
+```
+- [ ] **Step 2: Verify**
+```bash
+for r in rcan-spec rcan-py rcan-ts; do echo "== $r =="; ls ~/$r/CODEOWNERS ~/$r/CONTRIBUTING.md; grep -c 'Stewarded by the Robot Registry Foundation' ~/$r/README.md; done
+```
+Expected: files exist; grep count `1` each.
+- [ ] **Step 3: Commit each** `git -C ~/$r commit -am "docs: add CODEOWNERS + foundation stewardship note"` (per repo).
+
+- [ ] **Step 4: [OPERATOR] Push + PR** the Phase-4 commits on each trio repo's branch (after go-ahead).
+
+> Consumer-repo README/badge links (Category B, redirect-covered) are intentionally **out of scope** here — opportunistic only.
+
+---
+
+## Phase 5 — Verify (exit gate)
+
+### Task 5.1: [AGENT] Grep gate — zero CI refs remain
+
+- [ ] **Step 1: Assert no `continuonai/rcan` in tracked CI/metadata across all 8 repos**
+```bash
+fail=0
+for r in rcan-spec rcan-py rcan-ts OpenCastor robot-md robot-md-gateway robot-md-mcp RobotRegistryFoundation; do
+  hits=$(git -C ~/$r grep -nI 'continuonai/rcan' -- '.github/**' 'pyproject.toml' 'package.json' 'src/index.ts' 'docs/ci-integration.md' 2>/dev/null)
+  if [ -n "$hits" ]; then echo "FAIL $r:"; echo "$hits"; fail=1; fi
+done
+[ "$fail" = 0 ] && echo "EXIT GATE PASS: zero CI/metadata refs to continuonai/rcan"
+```
+Expected: `EXIT GATE PASS`. (These run against the migration branches; the gate is meaningful once Phase 2/4 PRs are merged — re-run on the merged default branches.)
+
+### Task 5.2: [OPERATOR] Dry-run release confirms OIDC + action resolution
+
+- [ ] **Step 1:** After the Phase-2 PRs merge, dispatch a no-publish dry run to confirm the `emit-version-tuple` action resolves from the new owner and OIDC auth is wired:
+  - npm: Actions → `Release` → Run workflow with `publish_npm=false` on `rcan-ts` → confirm `build-and-test` + (if tagged) `emit-version-tuple` steps resolve with no "action not found" error.
+  - PyPI: tag a patch release (or use the existing `workflow_dispatch` backfill path) → confirm the `publish` job authenticates via OIDC (no `PYPI_TOKEN` used) and `emit-version-tuple` runs.
+- [ ] **Step 2: Verify** the published artifact (if a real release) appears on PyPI/npm and the Actions log shows OIDC token exchange (not token auth).
+
+### Task 5.3: [OPERATOR] Unfreeze
+
+- [ ] **Step 1:** Lift the release freeze announced in Task 0.2. Migration complete.
+
+---
+
+## Out of scope (separate follow-ups)
+- **Token retirement:** delete `PYPI_TOKEN` / `NPM_TOKEN` repo secrets + revoke the tokens — only after Task 5.2 proves OIDC works under the new owner. Tracked separately per operator decision.
+- Package renames / npm scoping.
+- Consumer-repo Category-B doc/badge link updates.
+- `rcan://…/continuonai/…` manufacturer-namespace URIs and historical CHANGELOG entries (intentionally preserved).

--- a/docs/superpowers/specs/2026-06-03-rcan-foundation-migration-design.md
+++ b/docs/superpowers/specs/2026-06-03-rcan-foundation-migration-design.md
@@ -1,0 +1,196 @@
+# RCAN → Robot Registry Foundation migration — design
+
+**Date:** 2026-06-03
+**Status:** Approved (brainstorming) — pending writing-plans
+**Anchor repo:** rcan-spec (the CI hub). Spans 8 repos.
+
+## 1. Goal & motivation
+
+Give the RCAN **standard + reference SDKs** a vendor-neutral home in the
+`RobotRegistryFoundation` GitHub org, alongside `robot-md` and the registry
+the protocol resolves against (`rcan.dev` / RRN). Today the RCAN trio lives in
+`continuonai` (the commercial org, beside OpenCastor / continuonos /
+Continuon-Cloud), which undercuts the "anyone can build on this standard"
+story.
+
+This is not a new direction: `rcan-spec/docs/governance/robot-registry-foundation.md`
+already states *"the RRF stewards the RCAN protocol specification."* This
+migration makes the repo home match the governance already written down.
+
+Triggered while setting up OIDC Trusted Publishing (a stale PyPI
+"pending trusted publisher" email). Because OIDC publishers are keyed to the
+GitHub **owner**, the publishers must be registered under the new owner — so
+the org move should happen *before* registering them, not after.
+
+## 2. Scope
+
+**Transfer set (3 repos — move org):**
+`continuonai/rcan-spec`, `continuonai/rcan-py`, `continuonai/rcan-ts`.
+
+**Edit set (8 repos — touch files):** the trio (transfer + edit) plus 5
+consumers that only need their CI `uses:` lines re-pointed:
+- `craigm26/OpenCastor`
+- `RobotRegistryFoundation/robot-md`
+- `RobotRegistryFoundation/robot-md-gateway`
+- `RobotRegistryFoundation/robot-md-mcp`
+- `craigm26/RobotRegistryFoundation`
+
+Worktrees `robot-md-redesign`, `robot-md-wt-export-to`, `robot-md-gateway-wt-21`
+share the parent repos' `.git` → covered automatically. The plugin-cache copy
+under `.claude/plugins/cache/...` is not a live repo → ignored.
+
+**Unaffected:** every `from rcan import …` / `pip install rcan` /
+`npm install rcan-ts` consumer. Repo transfer does **not** rename published
+packages, so all code/import dependencies keep working untouched.
+
+## 3. Dependency taxonomy (why the risk is bounded)
+
+Each consumer depends on the trio in one of three ways; only one is risky.
+
+| Cat | Kind | Effect of transfer | Examples |
+|-----|------|--------------------|----------|
+| **C** | Published-package import | **None** — package names unchanged | OpenCastor `from rcan import RCANMessage`; robot-md `from rcan import sign_body`; gateway `from rcan.audit_bundle import canonical_json` |
+| **B** | Doc / badge / link URL | Redirected (cosmetic) | READMEs, CHANGELOGs, SECURITY links |
+| **A** | **Shared CI Action `uses:`** | **Breaks if old name is ever recreated** → must update | every release pipeline's `uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3` |
+
+**Why update Cat-A rather than trust redirects:** GitHub documents redirects
+for links and git operations, but not for Actions `uses:`. After transfer the
+old name `continuonai/rcan-spec` becomes *available*; if anyone (or an
+attacker) re-creates it, every consumer's `uses:` silently re-points to the new
+repo at that name — a supply-chain hazard for a CI action. Treat the redirect
+as a safety net for the migration window only; the end state must have **zero**
+`continuonai/rcan` refs in tracked CI files.
+
+### CI-hub actions (two, not one)
+1. `rcan-spec/.github/actions/emit-version-tuple` — referenced `@v3.2.3` by the
+   trio + all 5 consumers (signed version-tuple emit on release).
+2. `rcan-py/.github/actions/validate-rcan` — referenced `@main`, documented in
+   `rcan-py/docs/ci-integration.md` for *external* users' CI. We don't control
+   external callers (they rely on redirect), but our own repos must be swept and
+   the docs updated to the new owner.
+
+> Implementation note: reference locations below were captured at discovery
+> time; the rcan-py/rcan-ts `publish.yml` line numbers shifted after the OIDC
+> edit. **Re-grep at implementation time** rather than trusting line numbers:
+> `git grep -n 'continuonai/rcan'` per repo.
+
+## 4. Method
+
+GitHub **repository transfer** (`Settings → Transfer`, or `gh api -X POST
+/repos/continuonai/<repo>/transfer -f new_owner=RobotRegistryFoundation`).
+Preserves issues, PRs, wiki, stars, watchers, full git history, **tags +
+releases**, and per GitHub docs *"webhooks, services, secrets, or deploy keys …
+remain associated after the transfer."* Creates URL redirects.
+
+**Approaches considered:**
+- **(1) Coordinated transfer + immediate ecosystem sweep — CHOSEN.** Transfer,
+  then immediately update all Cat-A refs across the 8 repos, register OIDC
+  publishers under the new owner, verify. Redirect covers the brief window.
+- (2) Transfer + rely on redirects, update lazily. Rejected: redirect
+  impermanence = silent CI fragility / supply-chain risk; also leaves the org
+  inconsistent, defeating the goal.
+- (3) Decouple the actions first (publish to Marketplace / vendor them).
+  Rejected: over-engineered (YAGNI) for a one-time move.
+
+## 5. Plan (phases)
+
+### Phase 0 — Pre-flight (no changes)
+- Confirm admin on `continuonai` (source) and create-repo rights on
+  `RobotRegistryFoundation` (target). Both are in the operator's org list.
+- Snapshot each trio repo's **Actions secrets** and the `pypi` **environment**
+  (names + protection rules) so we can verify post-transfer. Trio secrets seen:
+  `PYPI_TOKEN`, `NPM_TOKEN`, `RCAN_PY_RELEASE_{RAN,PQ_PRIV,KID,PRIV}`,
+  `RCAN_TS_RELEASE_{RAN,PQ_PRIV,KID,PRIV}` (+ any rcan-spec notify token).
+- **Freeze releases ecosystem-wide** for the migration window (no `v*` tags /
+  release dispatches on the 8 repos until the sweep is verified).
+
+### Phase 1 — Transfer the 3 repos
+- Transfer `rcan-spec`, `rcan-py`, `rcan-ts` → `RobotRegistryFoundation`.
+- Update local git remotes (`git remote set-url origin …RobotRegistryFoundation/<repo>.git`).
+- Sanity-check tags/releases/secrets/environment landed (Phase 0 snapshot).
+
+### Phase 2 — Re-point the CI hub (load-bearing)
+Rewrite, across the 8 repos, in tracked CI files:
+- `uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3`
+  → `uses: RobotRegistryFoundation/rcan-spec/.github/actions/emit-version-tuple@v3.2.3`
+  - trio: `rcan-py/.github/workflows/publish.yml` (×2),
+    `rcan-ts/.github/workflows/publish.yml` (×2)
+  - consumers: `OpenCastor/.github/workflows/release.yml` (×2),
+    `robot-md/.github/workflows/release.yml` (×2),
+    `robot-md-gateway/.github/workflows/release.yml` (×2),
+    `robot-md-mcp/.github/workflows/release.yml` (×2),
+    `RobotRegistryFoundation/.github/workflows/release.yml`
+- Intra-trio `gh ... --repo continuonai/rcan-*`:
+  `rcan-py/.github/workflows/publish.yml` (`--repo continuonai/rcan-py`),
+  `rcan-spec/.github/workflows/release-notify.yml`
+  (`--repo continuonai/rcan-py`, `--repo continuonai/rcan-ts`).
+- The OIDC comment I added in `rcan-ts/publish.yml` ("org continuonai") → update.
+- `validate-rcan` action references in `rcan-py/docs/ci-integration.md` (and any
+  in-repo `uses:`) → new owner.
+
+### Phase 3 — Publishing trust under the new owner
+- Register OIDC trusted publishers (operator, browser):
+  - PyPI `rcan`: owner `RobotRegistryFoundation`, repo `rcan-py`, workflow
+    `publish.yml`, environment **`pypi`** — **from the PyPI account that owns
+    `rcan`** (note the cmmerry@ucdavis vs craigm26@gmail account ambiguity from
+    the original OIDC task).
+  - npm `rcan-ts`: org `RobotRegistryFoundation`, repo `rcan-ts`, workflow
+    `publish.yml`, environment **blank**.
+- Verify `RCAN_*_RELEASE_*` secrets + the `pypi` environment survived the
+  transfer; re-add any that didn't (env secrets are not documented as
+  transferred).
+
+### Phase 4 — Metadata + governance polish
+- Package metadata → new owner: `rcan-py/pyproject.toml` `Repository`;
+  `rcan-ts/package.json` `repository`/`bugs`/`homepage`; `rcan-ts/src/index.ts`
+  `@see`.
+- READMEs (badges + cross-links), `SECURITY.md` advisory links, `CLAUDE.md`
+  repo refs across the trio.
+- Governance doc `rcan-spec/docs/governance/robot-registry-foundation.md`
+  ("hosted at github.com/continuonai/rcan-spec" → RRF).
+- **Governance polish:** add `CODEOWNERS` (foundation maintainers), a
+  `CONTRIBUTING` pointer, and a one-line *"Stewarded by the Robot Registry
+  Foundation"* note in each trio README.
+- Consumer-repo doc/badge links (Cat-B): opportunistic, redirect-covered.
+
+### Phase 5 — Verify (exit gate)
+- `workflow_dispatch` dry-run / test release confirming: OIDC publish works
+  under the new owner, and `emit-version-tuple` resolves from
+  `RobotRegistryFoundation/rcan-spec`.
+- Grep gate: **zero** matches for `continuonai/rcan` in tracked CI files
+  (`*.yml`/`*.yaml`) across all 8 repos.
+- Unfreeze releases.
+
+## 6. Out of scope / non-goals
+- **Token retirement is a SEPARATE follow-up** (operator decision): deleting
+  `PYPI_TOKEN`/`NPM_TOKEN` repo secrets + revoking the tokens happens *after* a
+  verified OIDC release under the new owner — tracked elsewhere, not in this
+  migration.
+- No package renames or npm scoping (rcan-ts deliberately stays unscoped; PyPI
+  stays `rcan`).
+- Leave `rcan://…/continuonai/…` example URIs — there `continuonai` is a
+  **manufacturer namespace**, not a GitHub org.
+- Leave historical CHANGELOG entries (e.g. `@continuonai/rcan-ts`) as a record.
+- The OpenAPI schema `example: "github:continuonai"` is an illustrative value —
+  optional to touch.
+
+## 7. Risks → mitigations
+| Risk | Mitigation |
+|------|-----------|
+| `uses:` redirect impermanence / old-name recreation (supply-chain) | Phase 2 sweep to zero refs; exit-gate grep |
+| A release fires mid-window | Phase 0 ecosystem freeze |
+| Env secrets / `pypi` environment not carried over | Phase 3 verify + re-add |
+| OIDC publisher registered from the wrong/old owner or wrong PyPI account | Phase 3 explicit owner + account check |
+| External callers of `validate-rcan@main` (outside our control) | Redirect covers them; update our docs to new owner |
+
+## 8. Rollback
+Repo transfers are reversible (transfer back to `continuonai`). Before a
+verified OIDC release, publishing still works via the existing token path
+(unchanged until the separate retirement step), so a mid-migration abort leaves
+publishing functional. Workflow edits are ordinary commits → revert.
+
+## 9. Prerequisites / open items
+- Operator performs the GitHub transfers and the PyPI/npm publisher
+  registrations (cannot be scripted headlessly here).
+- Resolve which PyPI account owns `rcan` before registering its publisher.
+- Confirm no in-flight release is mid-pipeline at freeze time.


### PR DESCRIPTION
Part of moving the RCAN standard + reference SDKs from the `continuonai`
company org to the neutral **Robot Registry Foundation**, beside `robot-md`.
This fulfils the stewardship already asserted in
`docs/governance/robot-registry-foundation.md`. Ships alongside the GitHub repo
transfer; published package names are unchanged.

Changes:
- CI: `release-notify.yml` + the `emit-version-tuple` action README now point at
  `RobotRegistryFoundation/rcan-{py,ts,spec}`.
- Docs: README badges/links, `SECURITY.md` advisory link, `CLAUDE.md`, and the
  governance doc re-pointed to the new owner.
- Governance: add `CODEOWNERS`, `CONTRIBUTING.md`, and a "stewarded by the Robot
  Registry Foundation" note in the README.
- Includes the migration spec + plan under `docs/superpowers/`.

No CHANGELOG entries or `rcan://…/continuonai/…` manufacturer-namespace URIs were
touched. Trusted-publishing / OIDC and token retirement are tracked separately.

(Optional: if you'd rather keep the internal migration spec/plan out of the public
repo, drop the first two commits — `8eb8f4c`, `e92efb8` — and force-push.)
